### PR TITLE
Add multistake proposal

### DIFF
--- a/proposals/0022-multi-stake.md
+++ b/proposals/0022-multi-stake.md
@@ -18,7 +18,7 @@ for simpler stake movement through more activations, deactivations, or redelegat
 ## New Terminology
 
 * "multi stake": a stake account with multiple `Delegation` instances
-* "small stake": a stake whose delegation is a small lamport amount
+* "small stake": a stake whose delegation is less than current minimum stake delegation amount
 
 ## Motivation
 
@@ -31,7 +31,8 @@ eventually cleaning up the old one, which can be tricky to use.
 
 As a minimum stake delegation amount is applied to the network, and potentially
 increased over time, these operations will become more complicated, since all
-delegations must clear that threshold. A lot of small stake will be left liquid.
+delegations must clear that threshold. Small SOL amounts will be left liquid rather
+than delegated to a validator.
 
 Additionally, stake pools always carry some risk or capital inefficiency for the
 stake pool operator. Either there's a requirement to leave liquid SOL available

--- a/proposals/0022-multi-stake.md
+++ b/proposals/0022-multi-stake.md
@@ -41,8 +41,8 @@ to cover the minimum delegation amount.
 Small stakes need to be delegated, while not causing problems in the validator's
 stakes cache.
 
-Side note: this isn't my first proposal for a new stake account type. Here's an earlier
-attempt meant for redelegation: https://github.com/solana-labs/solana/pull/24762
+For more background, here's an earlier proposal meant for only for redelegation:
+https://github.com/solana-labs/solana/pull/24762
 
 ## Alternatives Considered
 
@@ -102,7 +102,7 @@ To add a small stake to your account, transfer the lamports, call `delegate` onc
 more, and now your stake account has two delegations: the initial one, and the
 newly activating one.
 
-Once the new `Delegation` is active, a permissionless `update` instruction follows
+Once the new `Delegation` is active, an `update` instruction follows
 the existing `merge` logic to consolidate the two `Delegation`s into one.
 
 The same roughly applies for removing a small stake. You `deactivate` a portion
@@ -117,7 +117,16 @@ within the same account.
 It works the same as the existing "redelegate" instruction, except the lamports
 all stay in the same account, and the second `Delegation` covers the redelegation.
 
-The permissionless `update` instruction clears out the first one once it's inactive.
+The `update` instruction clears out the first one once it's inactive.
+
+### Upgrade
+
+The stake program exposes a new instruction to upgrade a stake account to a multi-stake
+account. It performs a realloc to the new size of the stake account, and
+updates the rent-exempt reserve field in the stake account `Meta`.
+
+It must be signed by the current staker or withdrawer, and takes an optional
+payer to fund the additional rent-exempt reserve requirement.
 
 ### Runtime
 

--- a/proposals/0022-multi-stake.md
+++ b/proposals/0022-multi-stake.md
@@ -49,7 +49,6 @@ rewards. Meaning:
 * they don't take up space in the stakes cache
 * they take the correct amount of epoch boundaries to activate / deactivate
 * they are included in a validator's voting power
-* they can be slashed
 
 There are a few ways of solving this at the stakes cache level, and they all have
 serious issues.
@@ -74,8 +73,6 @@ stake delegation amount.
 
 During rewards payout, small stakes are completely omitted, since they are not
 present in the cache.
-
-During a slashing event, it's still possible to query it using `get_program_accounts`.
 
 This is incredibly brittle, however, and introduces more overhead in the runtime.
 The bank must hold onto pre-states for all transactions to debit the stakes cache. And,

--- a/proposals/0022-multi-stake.md
+++ b/proposals/0022-multi-stake.md
@@ -1,0 +1,181 @@
+---
+simd: '0022'
+title: Multi Stake Account
+authors:
+  - Jon Cinque (Solana Labs)
+category: Standard
+type: Core
+status: Draft
+created: 2023-01-20
+feature: (fill in with feature tracking issues once accepted)
+---
+
+## Summary
+
+A new "multi stake" account that allows for multiple movements of stake, useful
+for redelegations, stake pools, and ordinary stakers.
+
+## New Terminology
+
+* "small stake": a stake whose delegation is below the minimum delegation
+lamport amount, currently set to be 1 SOL
+* "multi stake": a stake account with multiple `Delegation` instances
+
+## Motivation
+
+As a minimum stake delegation amount is applied to the network, and potentially
+increased over time, it will become harder for small stakers to participate in
+the network.
+
+Current solutions through stake pools still carry some risk or capital inefficiency
+for the stake pool operator. Either there's a requirement to leave liquid SOL available
+for small stakers to exit, or small stakes cannot enter because there's not enough
+to cover the minimum delegation amount.
+
+Small stakes need to be delegated, while not causing problems in the validator's
+stakes cache.
+
+Side note: this isn't my first proposal for a new stake account type. Here's an earlier
+attempt meant for redelegation: https://github.com/solana-labs/solana/pull/24762
+
+## Alternatives Considered
+
+The easiest solution is to change the validator's stakes cache, since that only
+impacts the specific implementation in the Solana Labs validator.
+
+In the perfect situation, small stakes are properly delegated, but don't receive
+rewards. Meaning:
+
+* they don't take up space in the stakes cache
+* they take the correct amount of epoch boundaries to activate / deactivate
+* they are included in a validator's voting power
+* they can be slashed
+
+There are a few ways of solving this at the stakes cache level, and they all have
+serious issues.
+
+* Include small stakes in the cache, but don't pay out rewards
+
+This is the simplest solution, which essentially changes "minimum delegation amount"
+to mean "minimum reward earning amount". So you can delegate stake accounts with
+less than the minimum delegation, but they won't earn rewards.
+
+Unfortunately, small stakes can still bloat the stakes cache from a memory level.
+
+* Don't include small stakes in the cache, but track them in transactions
+
+In this solution, on every transaction, if the runtime sees a small stake, it
+includes its delegation amount in the validator's voting power, but doesn't
+add its pubkey and `Delegation` to the cache.
+
+The runtime tracks the pre and post state of every account, and for a successful
+transaction, subtracts the old small stake delegation amount, and adds the new small
+stake delegation amount.
+
+During rewards payout, small stakes are completely omitted, since they are not
+present in the cache.
+
+During a slashing event, it's still possible to query it using `get_program_accounts`.
+
+This is incredibly brittle, however, and introduces more overhead in the runtime.
+The bank must hold onto pre-states for all transactions to debit the stakes cache. And,
+if called from the outside, all `store_accounts` functions on the bank could easily
+invalidate the stakes cache.
+
+For example, if you store a small stake directly, what does the cache do? What
+was the pre-state of that small stake? There's no way to know.
+
+## Detailed Design
+
+Rather than hacking the validator, let's change the stake program.
+
+With a new "multi stake" account, carrying *two* more `Delegation`s, the stake
+program becomes much more flexible.
+
+During initial delegation, the "multi stake" account must have enough to cover
+the minimum stake delegation amount. The two other `Delegation` instances may be
+used for small stake movements.
+
+Here are some example uses:
+
+### Add or remove small stake
+
+To add a small stake to your account, transfer the lamports, call `delegate` once
+more, and now your stake account has two delegations: the initial one, and the
+newly activating one.
+
+Once the new `Delegation` is active, a permissionless `update` instruction follows
+the existing `merge` logic to consolidate the two `Delegation`s into one.
+
+The same roughly applies for removing a small stake. You `deactivate` a portion
+of it, which adds another delegation to your stake account: the initial one, and
+the newly deactivating one.
+
+### Redelegate
+
+With another `Delegation` instance, you can redelegate from one validator to another
+within the same account.
+
+It works the same as the existing "redelegate" instruction, except the lamports
+all stay in the same account, and the second `Delegation` covers the redelegation.
+
+The permissionless `update` instruction clears out the first one once it's inactive.
+
+### Single validator stake pool
+
+A single-validator stake pool program can manage small stakes with 100% efficiency
+using "multi stakes".
+
+Since there's a total of *three* `Delegation` instances, small stakes can be added
+and removed at the same time. One instance covers the main amount, another covers
+new activations, and the last one covers deactivations.
+
+For small stake deposit, you simply transfer the lamports and activate the new amount.
+
+For small stake withdrawal, the program deactivates the small stake and provides
+a claimable ticket to the user, used to claim their lamports after deactivation.
+
+### Runtime
+
+The main difference to the runtime is processing up to three `Delegation`s
+per account.
+
+There's minor impact on the stakes cache, which gets a little bigger, but the
+maximum is bounded by the minimum delegation amount.
+
+There's minor impact on rewards payout, since the time spent calculating the rewards
+amount is negligible compared to the time spent storing the accounts. The number
+of account storages stays the same.
+
+## Impact
+
+Validators likely see a small increase in memory usage from additional `Delegation`
+entries in the stakes cache, and perhaps a tiny increase in rewards payout time,
+but nothing substantial.
+
+Dapp developers have to deal with a new stake account type. This may break programs
+that try to deserialize any stake account.
+
+The network benefits as a whole:
+
+* stake accounts are more flexible for adding or removing stake, without splits and merges
+* stakers can easily redelegate without losing funds
+* single-validator stake pools can be just about 100% capital efficient
+
+## Security Considerations
+
+It's risky to change the runtime, especially the stake program and rewards payout.
+Thankfully, since this all operates on the level of the `Delegation`, as long
+as we pass all the instances as needed, none of the most sensitive parts need
+to change.
+
+## Drawbacks *(Optional)*
+
+We could just change the stakes cache include small stakes, but not in rewards
+payout, and everything mostly works, but it's ultimately a temporary solution.
+
+## Backwards Compatibility *(Optional)*
+
+While existing programs that create and use their own stake accounts are not impacted,
+those that accept any stake account will crash on multi-stakes. There's no way
+around that, since the proposal entails a new stake account variant.

--- a/proposals/0022-multi-stake.md
+++ b/proposals/0022-multi-stake.md
@@ -91,7 +91,7 @@ was the pre-state of that small stake? There's no way to know.
 
 Rather than hacking the validator, let's change the stake program.
 
-With a new "multi delegation stake" account, carrying *three* `Delegation` instances,
+With a new "multi delegation stake" account, carrying *two* `Delegation` instances,
 the stake program becomes much more flexible.
 
 Here are some example uses:
@@ -121,7 +121,7 @@ The permissionless `update` instruction clears out the first one once it's inact
 
 ### Runtime
 
-The main difference to the runtime is processing up to three `Delegation`s
+The main difference to the runtime is processing up to two `Delegation`s
 per account.
 
 There's minor impact on the stakes cache, which gets a little bigger for the
@@ -163,12 +163,12 @@ around that, since the proposal entails a new stake account variant.
 A single-validator stake pool program can manage small stakes with 100% efficiency
 using "multi stakes".
 
-Since there's a total of *three* `Delegation` instances, small stakes can be added
-and removed at the same time. One instance covers the main amount, another covers
-new activations, and the last one covers deactivations.
+With a total of *two* `Delegation` instances, the program can add or remove small
+stakes. One instance covers the main amount, and the other covers new activations
+or deactivations.
 
 For small stake deposit, you simply transfer the lamports and activate the new amount.
 
-For small stake withdrawal, the program deactivates the small stake and provides
-a claimable ticket to the user, used to claim their lamports after deactivation.
-
+If a user wishes to withdraw, the program first withdraws from the activating amount.
+If there is no more activating amount available, then the pool deactivates from
+the main delegation and provides a ticket to the user, used to claim their lamports after deactivation.

--- a/proposals/0022-multi-stake.md
+++ b/proposals/0022-multi-stake.md
@@ -1,6 +1,6 @@
 ---
 simd: '0022'
-title: Multi Stake Account
+title: Multi Delegation Stake Account
 authors:
   - Jon Cinque (Solana Labs)
 category: Standard
@@ -13,22 +13,28 @@ feature: (fill in with feature tracking issues once accepted)
 ## Summary
 
 A new "multi stake" account that allows for multiple movements of stake, useful
-for redelegations, stake pools, and ordinary stakers.
+for simpler stake movement through more activations, deactivations, or redelegation.
 
 ## New Terminology
 
-* "small stake": a stake whose delegation is below the minimum delegation
-lamport amount, currently set to be 1 SOL
 * "multi stake": a stake account with multiple `Delegation` instances
+* "small stake": a stake whose delegation is a small lamport amount
 
 ## Motivation
 
-As a minimum stake delegation amount is applied to the network, and potentially
-increased over time, it will become harder for small stakers to participate in
-the network.
+Stake operations are cumbersome or impossible for many ordinary uses. For example,
+delegating more lamports in an existing stake account requires creating a new
+account, delegating, waiting, merging, then withdrawing the rent-exempt lamports.
 
-Current solutions through stake pools still carry some risk or capital inefficiency
-for the stake pool operator. Either there's a requirement to leave liquid SOL available
+The current stake `redelegate` instruction requires using a new stake account and
+eventually cleaning up the old one, which can be tricky to use.
+
+As a minimum stake delegation amount is applied to the network, and potentially
+increased over time, these operations will become more complicated, since all
+delegations must clear that threshold. A lot of small stake will be left liquid.
+
+Additionally, stake pools always carry some risk or capital inefficiency for the
+stake pool operator. Either there's a requirement to leave liquid SOL available
 for small stakers to exit, or small stakes cannot enter because there's not enough
 to cover the minimum delegation amount.
 
@@ -55,15 +61,14 @@ serious issues.
 
 * Include small stakes in the cache, but don't pay out rewards
 
-This is the simplest solution, which essentially changes "minimum delegation amount"
-to mean "minimum reward earning amount". So you can delegate stake accounts with
-less than the minimum delegation, but they won't earn rewards.
+This is the simplest solution, which essentially imposes a "minimum reward earning
+amount". So you can delegate small stakes, but they won't earn rewards.
 
 Unfortunately, small stakes can still bloat the stakes cache from a memory level.
 
 * Don't include small stakes in the cache, but track them in transactions
 
-In this solution, on every transaction, if the runtime sees a small stake, it
+In this solution, on every transaction that manipulates a small stake delegation, it
 includes its delegation amount in the validator's voting power, but doesn't
 add its pubkey and `Delegation` to the cache.
 
@@ -86,12 +91,8 @@ was the pre-state of that small stake? There's no way to know.
 
 Rather than hacking the validator, let's change the stake program.
 
-With a new "multi stake" account, carrying *two* more `Delegation`s, the stake
-program becomes much more flexible.
-
-During initial delegation, the "multi stake" account must have enough to cover
-the minimum stake delegation amount. The two other `Delegation` instances may be
-used for small stake movements.
+With a new "multi delegation stake" account, carrying *three* `Delegation` instances,
+the stake program becomes much more flexible.
 
 Here are some example uses:
 
@@ -118,27 +119,13 @@ all stay in the same account, and the second `Delegation` covers the redelegatio
 
 The permissionless `update` instruction clears out the first one once it's inactive.
 
-### Single validator stake pool
-
-A single-validator stake pool program can manage small stakes with 100% efficiency
-using "multi stakes".
-
-Since there's a total of *three* `Delegation` instances, small stakes can be added
-and removed at the same time. One instance covers the main amount, another covers
-new activations, and the last one covers deactivations.
-
-For small stake deposit, you simply transfer the lamports and activate the new amount.
-
-For small stake withdrawal, the program deactivates the small stake and provides
-a claimable ticket to the user, used to claim their lamports after deactivation.
-
 ### Runtime
 
 The main difference to the runtime is processing up to three `Delegation`s
 per account.
 
-There's minor impact on the stakes cache, which gets a little bigger, but the
-maximum is bounded by the minimum delegation amount.
+There's minor impact on the stakes cache, which gets a little bigger for the
+additional `Delegation` instances.
 
 There's minor impact on rewards payout, since the time spent calculating the rewards
 amount is negligible compared to the time spent storing the accounts. The number
@@ -156,8 +143,7 @@ that try to deserialize any stake account.
 The network benefits as a whole:
 
 * stake accounts are more flexible for adding or removing stake, without splits and merges
-* stakers can easily redelegate without losing funds
-* single-validator stake pools can be just about 100% capital efficient
+* stakers can easily redelegate without missing out on rewards
 
 ## Security Considerations
 
@@ -166,13 +152,23 @@ Thankfully, since this all operates on the level of the `Delegation`, as long
 as we pass all the instances as needed, none of the most sensitive parts need
 to change.
 
-## Drawbacks *(Optional)*
-
-We could just change the stakes cache include small stakes, but not in rewards
-payout, and everything mostly works, but it's ultimately a temporary solution.
-
 ## Backwards Compatibility *(Optional)*
 
 While existing programs that create and use their own stake accounts are not impacted,
 those that accept any stake account will crash on multi-stakes. There's no way
 around that, since the proposal entails a new stake account variant.
+
+## Appendix: Single validator stake pool
+
+A single-validator stake pool program can manage small stakes with 100% efficiency
+using "multi stakes".
+
+Since there's a total of *three* `Delegation` instances, small stakes can be added
+and removed at the same time. One instance covers the main amount, another covers
+new activations, and the last one covers deactivations.
+
+For small stake deposit, you simply transfer the lamports and activate the new amount.
+
+For small stake withdrawal, the program deactivates the small stake and provides
+a claimable ticket to the user, used to claim their lamports after deactivation.
+


### PR DESCRIPTION
Proposal to create a new kind of stake account. The main use-case is to properly support single-validator stake pools for small stakers, but provides benefits to every staker.