### PR TITLE
Add living status, supercede, extends, and rfc 2119 recommendation to template

### DIFF
--- a/XXXX-template.md
+++ b/XXXX-template.md
@@ -8,6 +8,8 @@ type: Core/Networking/Interface/Meta
 status: Draft
 created: (fill me in with today's date, YYYY-MM-DD)
 feature: (fill in with feature tracking issues once accepted)
+supercedes: (optional - fill this in if the SIMD supercedes a previous SIMD)
+extends: (optional - fill this in if the SIMD extends the design of a previous SIMD)
 ---
 
 ## Summary

--- a/XXXX-template.md
+++ b/XXXX-template.md
@@ -39,6 +39,8 @@ to another Solana core contributor. The generally means:
 - Interaction with other features
 - Edge cases
 
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt) and [RFC 8174](https://www.ietf.org/rfc/rfc8174.txt).
+
 ## Impact
 
 How will the implemented proposal impacts dapp developers, validators, and core contributors?

--- a/XXXX-template.md
+++ b/XXXX-template.md
@@ -9,7 +9,8 @@ status: Draft
 created: (fill me in with today's date, YYYY-MM-DD)
 feature: (fill in with feature tracking issues once accepted)
 supercedes: (optional - fill this in if the SIMD supercedes a previous SIMD)
-extends: (optional - fill this in if the SIMD extends the design of a previous SIMD)
+extends: (optional - fill this in if the SIMD extends the design of a previous
+ SIMD)
 ---
 
 ## Summary
@@ -41,7 +42,11 @@ to another Solana core contributor. The generally means:
 - Interaction with other features
 - Edge cases
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt) and [RFC 8174](https://www.ietf.org/rfc/rfc8174.txt).
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this
+document are to be interpreted as described in [RFC
+2119](https://www.ietf.org/rfc/rfc2119.txt) and [RFC
+8174](https://www.ietf.org/rfc/rfc8174.txt).
 
 ## Impact
 

--- a/proposals/0001-simd-process.md
+++ b/proposals/0001-simd-process.md
@@ -162,7 +162,8 @@ implementing their accepted feature.
 
 ### Living
 
-A special status for SIMDs that are designed to be continually updated and not reach a state of finality. This includes most notably SIMD-1.
+A special status for SIMDs that are designed to be continually updated and not
+reach a state of finality. This includes most notably SIMD-1.
 
 ### Stagnant
 

--- a/proposals/0001-simd-process.md
+++ b/proposals/0001-simd-process.md
@@ -5,7 +5,7 @@ authors:
   - Jacob Creech (Solana Foundation)
 category: Meta
 type: Meta
-status: Draft
+status: Living
 created: 2022-10-18
 ---
 
@@ -68,7 +68,7 @@ Proposals but apply to areas other than the Solana protocol itself. They may
 propose an implementation, but not to Solana's codebase; they often require
 community consensus and users are typically not free to ignore them. Examples
 include procedures, guidelines, changes to the decision-making process, and
-changes to the tools or environment used in Solana development. Any meta-EIP is
+changes to the tools or environment used in Solana development. Any meta-SIMD is
 also considered a Process Proposals.
 
 ## Proposal Lifecycle
@@ -79,6 +79,7 @@ The stages in a lifecycle of a proposal are as follows:
 - Draft
 - Review
 - Accepted
+- Living
 - Stagnant
 - Withdrawn
 - Implemented
@@ -101,6 +102,7 @@ flowchart LR
   Idea ---> Draft;
   Draft ---> Review;
   Review ---> Accepted;
+  Review ---> Living;
 
   Draft ---> Stagnant;
   Review ---> Stagnant;
@@ -157,6 +159,10 @@ issue for tracking across clusters should also be created. While it is not
 far the most effective way to see a proposal through to completion: authors
 should not expect that other project developers will take on responsibility for
 implementing their accepted feature.
+
+### Living
+
+A special status for SIMDs that are designed to be continually updated and not reach a state of finality. This includes most notably SIMD-1.
 
 ### Stagnant
 

--- a/proposals/0001-simd-process.md
+++ b/proposals/0001-simd-process.md
@@ -163,7 +163,9 @@ implementing their accepted feature.
 ### Living
 
 A special status for SIMDs that are designed to be continually updated and not
-reach a state of finality. This includes most notably SIMD-1.
+reach a state of finality. This includes most notably SIMD-1. This status must
+undergo extra scrutiny and review when updating the status from review to
+living.
 
 ### Stagnant
 


### PR DESCRIPTION
While there is a possibility for some SIMDs to be updated in the future, I'd like those SIMDs to be directly noted as updatable. Otherwise we should write new SIMDs that `supercede` or `extend` previous SIMDs.