### PR TITLE
SIMD-0082: Relax Transaction Constraints

### DIFF
--- a/proposals/0082-relax-transaction-constraints.md
+++ b/proposals/0082-relax-transaction-constraints.md
@@ -8,8 +8,6 @@ type: Core
 status: Draft
 created: 2023-10-30
 feature:
-supersedes:
-extends:
 ---
 
 ## Summary

--- a/proposals/0082-relax-transaction-constraints.md
+++ b/proposals/0082-relax-transaction-constraints.md
@@ -62,7 +62,7 @@ remove one of the barriers to asynchronous execution.
     significant benefits to the network.
 3. Additionally, relax the address lookup table resolution constraint
     - This was considered, since it is a transaction-level constraint that is
-    depdendent on account-state. However, due to entry-level and block-level
+    dependent on account-state. However, due to entry-level and block-level
     constraints that rely on the address lookup table resolution, this
     constraint cannot easily be relaxed without also relaxing those
     constraints.
@@ -105,7 +105,7 @@ transaction level are:
     - The total number of accounts, static or dynamic, must be less than 256.
     - Each instruction's `program_id_index` must be less than the number of
       static account keys.
-    - Each intruction's `program_id_index` must not be the payer index (0).
+    - Each instruction's `program_id_index` must not be the payer index (0).
     - All account indices in instructions must be less than the number of total
       accounts.
 7. Transactions that use address look up tables must be resolvable:
@@ -181,7 +181,7 @@ Specifically, the following constraints will remain as protocol violations:
     - The total number of accounts, static or dynamic, must be less than 256.
     - Each instruction's `program_id_index` must be less than the number of
       static account keys.
-    - Each intruction's `program_id_index` must not be the payer index (0).
+    - Each instruction's `program_id_index` must not be the payer index (0).
     - All account indices in instructions must be less than the number of total
       accounts.
 7. Transactions that use address look up tables must be resolvable:

--- a/proposals/0082-relax-transaction-constraints.md
+++ b/proposals/0082-relax-transaction-constraints.md
@@ -132,11 +132,9 @@ transaction level are:
     - be owned by the system program: `11111111111111111111111111111111`
     - have more lamports than the fee
     - have more lamports than the fee plus the minimum balance
-14. Any non-writable program accounts used in the transaction must exist,
-    regardless of if they are used in any instructions.
-15. The total loaded data size of the transaction must not exceed
+14. The total loaded data size of the transaction must not exceed
     `requested_loaded_accounts_data_size_limit`, or the default limit (64MB).
-16. Any account used as a program in a top-level instruction must:
+15. Any account used as a program in a top-level instruction must:
     - be the native loader: `NativeLoader1111111111111111111111111111111`
     - OR
       - exist
@@ -216,11 +214,9 @@ will not be executed.
 3. The transaction must have fewer than 64 accounts.
     - The limit is subject to change to 128 with the activation of
       `9LZdXeKGeBV6hRLdxS1rHbHoEUsKqesCC2ZAPTPKJAbK`.
-4. Any non-writable program accounts used in the transaction must exist,
-   regardless of if they are used in any instructions.
-5. The total loaded data size of the transaction must not exceed
+4. The total loaded data size of the transaction must not exceed
    `requested_loaded_accounts_data_size_limit`, or the default limit (64MB).
-6. Any account used as a program in a top-level instruction must:
+5. Any account used as a program in a top-level instruction must:
     - be the native loader: `NativeLoader1111111111111111111111111111111`
     - OR
       - exist

--- a/proposals/0082-relax-transaction-constraints.md
+++ b/proposals/0082-relax-transaction-constraints.md
@@ -108,14 +108,14 @@ transaction level are:
     - Each instruction's `program_id_index` must not be the payer index (0).
     - All account indices in instructions must be less than the number of total
       accounts.
-7. Transactions that use address look up tables must be resolvable:
-    - The address look up table account must exist.
-    - The address look up table account must be owned by the address look up
+7. Transactions that use address lookup tables must be resolvable:
+    - The address lookup table account must exist.
+    - The address lookup table account must be owned by the address lookup
       table program: `AddressLookupTab1e1111111111111111111111111`
-    - The address look up table account data must be deserializable into
+    - The address lookup table account data must be deserializable into
       `AddressLookupTable` as defined in `solana-sdk`.
     - All account table indices specified in the transaction must be less than
-      the number of active addresses in the address look up table.
+      the number of active addresses in the address lookup table.
 8. Transactions containing pre-compile instructions must pass pre-compile
    verification checks.
 9. The transaction must not load the same account more than once.
@@ -184,14 +184,14 @@ Specifically, the following constraints will remain as protocol violations:
     - Each instruction's `program_id_index` must not be the payer index (0).
     - All account indices in instructions must be less than the number of total
       accounts.
-7. Transactions that use address look up tables must be resolvable:
-    - The address look up table account must exist.
-    - The address look up table account must be owned by the address look up
+7. Transactions that use address lookup tables must be resolvable:
+    - The address lookup table account must exist.
+    - The address lookup table account must be owned by the address lookup
       table program: `AddressLookupTab1e1111111111111111111111111`
-    - The address look up table account data must be deserializable into
+    - The address lookup table account data must be deserializable into
       `AddressLookupTable` as defined in `solana-sdk`.
     - All account table indices specified in the transaction must be less than
-      the number of active addresses in the address look up table.
+      the number of active addresses in the address lookup table.
 8. The `recent_blockhash` of the transaction message must be valid:
     - It must exist and not have an age greater than 150.
     - OR the transaction must be a nonced transaction, and the nonce

--- a/proposals/0082-relax-transaction-constraints.md
+++ b/proposals/0082-relax-transaction-constraints.md
@@ -89,7 +89,7 @@ transaction level are:
     ```
 
     where `Signature` and `VersionedMessage` are defined in `solana-sdk`.
-2. Transaction serialized side must be less than or equal to 1232 bytes.
+2. Transaction serialized size must be less than or equal to 1232 bytes.
 3. Transaction signatures must be valid and in the same order as the static
    account keys in the `VersionedMessage`.
 4. Transaction must have exactly the number of required signatures from the
@@ -163,7 +163,7 @@ Specifically, the following constraints will remain as protocol violations:
     ```
 
     where `Signature` and `VersionedMessage` are defined in `solana-sdk`.
-2. Transaction serialized side must be less than or equal to 1232 bytes.
+2. Transaction serialized size must be less than or equal to 1232 bytes.
 3. Transaction signatures must be valid and in the same order as the static
    account keys in the `VersionedMessage`.
 4. Transaction must have exactly the number of required signatures from the

--- a/proposals/0082-relax-transaction-constraints.md
+++ b/proposals/0082-relax-transaction-constraints.md
@@ -145,6 +145,22 @@ transaction level are:
       - be executable
       - the owner account be owned by the native loader: `NativeLoader1111111111111111111111111111111`
       - the owner account must be executable
+16. Durable nonce transactions must:
+    - use a recent blockhash value different from the durable nonce for the
+      current bank
+    - have at least one transaction instruction, the first of which is
+      designated the nonce advance instruction which must:
+        - invoke the system program `11111111111111111111111111111111`
+        - have instruction data that deserializes to the
+          `SystemInstruction::AdvanceNonceAccount` variant
+        - have at least one account input, the first of which is designated the
+          nonce address/account which must:
+           - be loaded with a write-lock
+           - be owned by the system program: `11111111111111111111111111111111`
+           - be deserializable to non-legacy initialized nonce state
+           - have a durable nonce hash equal to the transaction's recent
+             blockhash field
+    - be signed by the nonce authority deserialized from the nonce account
 
 ### Proposed Protocol-Violation Errors
 
@@ -200,6 +216,22 @@ Specifically, the following constraints will remain as protocol violations:
     - be owned by the system program: `11111111111111111111111111111111`
     - have more lamports than the fee
     - have more lamports than the fee plus the minimum balance
+11. Durable nonce transactions must:
+    - use a recent blockhash value different from the durable nonce for the
+      current bank
+    - have at least one transaction instruction, the first of which is
+      designated the nonce advance instruction which must:
+        - invoke the system program `11111111111111111111111111111111`
+        - have instruction data that deserializes to the
+          `SystemInstruction::AdvanceNonceAccount` variant
+        - have at least one account input, the first of which is designated the
+          nonce address/account which must:
+           - be loaded with a write-lock
+           - be owned by the system program: `11111111111111111111111111111111`
+           - be deserializable to non-legacy initialized nonce state
+           - have a durable nonce hash equal to the transaction's recent
+             blockhash field
+    - be signed by the nonce authority deserialized from the nonce account
 
 ### Proposed New Runtime Errors
 

--- a/proposals/0082-relax-transaction-constraints.md
+++ b/proposals/0082-relax-transaction-constraints.md
@@ -129,7 +129,7 @@ transaction level are:
 12. The transaction must not have already been processed.
 13. The transaction fee-payer account must:
     - exist
-    - be owned by the the system program: `11111111111111111111111111111111`
+    - be owned by the system program: `11111111111111111111111111111111`
     - have more lamports than the fee
     - have more lamports than the fee plus the minimum balance
 14. Any non-writable program accounts used in the transaction must exist,
@@ -199,7 +199,7 @@ Specifically, the following constraints will remain as protocol violations:
 9. The transaction must not have already been processed.
 10. The transaction fee-payer account must:
     - exist
-    - be owned by the the system program: `11111111111111111111111111111111`
+    - be owned by the system program: `11111111111111111111111111111111`
     - have more lamports than the fee
     - have more lamports than the fee plus the minimum balance
 

--- a/proposals/0082-relax-transaction-constraints.md
+++ b/proposals/0082-relax-transaction-constraints.md
@@ -150,7 +150,8 @@ transaction level are:
 
 ### Proposed Protocol-Violation Errors
 
-The proposal is to move some items of the above list from protocol violations to runtime errors.
+The proposal is to move some items of the above list from protocol violations
+to runtime errors.
 Specifically, the following constraints will remain as protocol violations:
 
 1. Transaction must be deserializable via `bincode` (or equivalent) into a structure:

--- a/proposals/0082-relax-transaction-constraints.md
+++ b/proposals/0082-relax-transaction-constraints.md
@@ -1,5 +1,5 @@
 ---
-simd: 'XXXX'
+simd: '0082'
 title: Relax Transaction Constraints
 authors:
   - Andrew Fitzgerald (Solana Labs)

--- a/proposals/XXXX-relax-transaction-constraints.md
+++ b/proposals/XXXX-relax-transaction-constraints.md
@@ -1,0 +1,175 @@
+---
+simd: 'XXXX'
+title: Relax Transaction Constraints
+authors:
+  - Andrew Fitzgerald (Solana Labs)
+category: Standard
+type: Core
+status: Draft
+created: 2023-10-30
+feature:
+supersedes:
+extends:
+---
+
+## Summary
+
+This proposal aims to relax some of the constraints on which individual
+transactions can be included in a valid block.
+The proposal does not relax the constraints required for a transaction to be
+executed.
+
+## Motivation
+
+The current protocol places many constraints on the structure and contents
+of blocks; if any constraints are broken, block-validators will mark the block
+as invalid.
+Many of these constraints are necessary, but some of them are not, and lead to
+additional complexity in the protocol.
+This proposal aims to relax some of the constraints at the individual
+transaction level, in order to simplify the protocol, and give more flexibility
+to block-producer and block-validator implementations.
+
+More specifically, this proposal aims to relax the constraints which require
+account state in order to determine the validity of a transaction's inclusion.
+The reason these constraints are targetted specifically, is that reliance on
+account state necessarily requires synchronous execution within the protocol.
+This proposal on its' own, will not enable asynchronous execution, but it will
+remove one of the barriers to asynchronous execution.
+
+## Alternatives Considered
+
+1. Do nothing
+    - This is the simplest option, as we could leave the protocol as is.
+    However, this leaves the protocol more complex than it needs to be.
+2. Relax all but fee-paying constraint
+    - This was actually the initial proposal, but it was decided that it would
+    be better to relax as many constraints as possible, rather than just some.
+    Any reliance on account state, means the protocol requires synchronous
+    execution.
+3. Additionally, relax the address lookup table resolution constraint
+    - This was considered, since it is a transaction-level constraint that is
+    depdendent on account-state. However, due to entry-level and block-level
+    constraints that rely on the address lookup table resolution, this
+    constraint cannot easily be relaxed without also relaxing those
+    constraints.
+
+## New Terminology
+
+None
+
+## Detailed Design
+
+Specifically, this proposal relaxes constraints that a transaction included in
+a block must:
+
+1. Have a fee-payer with enough funds to pay fees
+2. Have a valid nonce account, if specified
+3. Have program accounts that:
+   1. exist
+   2. are executable
+4. Have writable accounts that are:
+   1. not executable, unless owned by
+   `BPFLoaderUpgradeab1e11111111111111111111111`
+   2. if owned by `BPFLoaderUpgradeab1e11111111111111111111111`,
+   then `BPFLoaderUpgradeab1e11111111111111111111111` must be included
+   3. if owned by `Stake11111111111111111111111111111111111111`, then the
+   current slot must not be within the epoch stakes reward distribution period
+5. Have executable `BPFLoaderUpgradeab1e11111111111111111111111` owned accounts
+with `UpgradeableLoaderState::Program` state, and derived program data account
+that exist
+6. Have a call chain depth of 5 or less
+7. Have no builtin loader ownership chains
+(pending `4UDcAfQ6EcA6bdcadkeHpkarkhZGJ7Bpq7wTAiRMjkoi`)
+8. Have total loaded data size which does not exceed
+requested_loaded_accounts_data_size_limit
+(pending `DdLwVYuvDz26JohmgSbA7mjpJFgX5zP2dkp8qsF2C33V`)
+
+The intent with relaxing these constraints is to minimize the amount of
+account-state which is required in order to validate a block. This gives more
+flexibility to when and how account-state is updated during both block
+production and validation.
+
+With these constraints removed, there is still one account-state constraint
+at the transaction level: address lookup table resolution.
+With this proposal, this constraint is intentionally not relaxed since it is
+necessary for validation of entry-level and block-level constraints.
+However, if/when those constraints are relaxed, this constraint should be
+relaxed as well.
+
+The relaxation of these constraints is only relaxed for transactions being
+included in a block. During block validation, if any of these constraints
+are broken, the entire block is marked invalid; with this proposal, the
+block is not marked invalid, but the transaction will not be executed.
+These constraints must still be satisfied in order for the transaction to be
+executed, and have an effect on state. However, there are some new considerations
+which must be taken into account, specifically as it relates to fees and block
+limits.
+
+### Fee-Paying
+
+Currently, iff a transaction's fee-payer does not have enough funds to pay the
+fee, the transaction cannot be included in a block. With this proposal, it is
+possible for such a transaction to be included in the block, and there are
+three different edge-cases to consider:
+
+1. The fee-payer account does not exist (0 lamports)
+2. The fee-payer account does not have enough funds for the entire fee
+3. The fee-payer account has enough funds for the fee, but would no longer be
+rent-exempt
+
+In case 1, the transaction should simply be ignored for execution, and have no
+effect on state.
+In case 2, the fee-paying account should be drained of all funds, but have no
+other effect on state.
+In case 3, the fee-paying account should be drained of all funds, with fees
+being paid to the block-producer, and the remainder of lamports being dropped.
+
+### Block-Limits
+
+Pending the activation of `2ry7ygxiYURULZCrypHhveanvP5tzZ4toRwVp89oCNSj`,
+validators must validate a block is within block-limits.
+With this proposal, some transactions may not be executable, but will still
+count towards block-limits.
+If these transactions did not count towards block-limits, the validation of
+block-limits would require the validator to check whether or not a transaction
+is executable, which negates the benefits of this proposal.
+
+Additionally, f these transactions did not count towards block-limits, a
+malicious leader could produce a block with non-executable transactions and
+overload the network.
+
+## Impact
+
+- Transactions that would previously be dropped with an error, can now be
+  included, and even charged fees.
+  - Users must be more careful when constructing transactions to ensure they
+    are executable if they don't want to waste fees
+- The validity of a block is no longer dependent on intra-block account-state
+updates. This is because the only account-state required for transaction
+validation is the ALT resolution, which is resolved at the beginning of a slot.
+  - Block-production could be done asynchronously
+  - Block-validation could be done without execution, but still relies on the
+  execution of previous blocks.
+
+## Security Considerations
+
+- Removing fee-paying requirement could allow validator clients to produce
+  blocks that do not pay fees. If not checked by block-producer, this could
+  allow malicious users to abuse such producers/leaders.
+
+## Drawbacks
+
+- Any dynamic fees based on block utilization cannot/should not reward the
+block-producer directly. Otherwise, this incentivizes block-producers to fill
+blocks with non-fee paying transactions in order to raise fees.
+- Non-fee paying transactions included in a block will be recorded in long-term
+transaction history. Without any fees being paid, there is no way to reward
+long-term storage of these transactions. It is important to note, there is also
+currently no way to reward this storage.
+
+## Backwards Compatibility
+
+This proposal is backwards compatible with the current protocol, since it only
+relaxes constraints, and does not add any new constraints. All previously valid
+blocks would still be valid.


### PR DESCRIPTION
The first in a series of SIMDs aimed at the relaxation of constraints blocking us from (potentially) having asynchronous execution.
This proposal does not lock Solana into moving towards asynchronous execution.
This proposal stands on its own to simplify the protocol and give more flexibility in implementation of both block-production and block-validation.