### PR TITLE
SIMD-0087: Explicit Sign Extension in SBPFv2

### DIFF
--- a/proposals/0085-explicit-sign-extension-in-sbpfv2.md
+++ b/proposals/0085-explicit-sign-extension-in-sbpfv2.md
@@ -1,0 +1,175 @@
+---
+simd: '0085'
+title: Explicit Sign-Extension in SBPFv2
+authors:
+  - Liam Heeger (@CantelopePeel, @lheeger-jump)
+category: Standard
+type: Core
+status: Draft
+created: 2023-11-14
+feature: TBD
+supersedes:
+extends:
+---
+
+## Summary
+
+Add a sign extension instruction to SBPFv2 and replace implicit sign extension
+in certain SBPF instructions with zero extension. 
+
+## Motivation
+
+Currently many 32-bit ALU instructions in SBPF perform implicit sign extension 
+on inputs where it is not required or necessary.
+
+Removing implicit sign extension simplifies the virtual machine in both JIT and
+interpreted approaches and thereby improves performance.
+
+## Alternatives Considered
+
+NA
+
+## New Terminology
+
+NA
+
+## Detailed Design
+The instruction set changes proposed are two fold: 
+
+1. Add a new instruction to SBPFv2 for explicit sign extension.
+1. Change existing behavior of instructions in SBPFv2 to no longer do implicit
+sign extension.
+
+It is important to note that these changes do not affect existing programs and
+only affect the new SBPFv2 instruction set architecture.
+
+Appendix 1 contains additional functions used in the specification of 
+instructions.
+
+The new instruction is specified as follows:
+
+---
+### `SEXT64_REG` - Sign Extension 64-Bit Instruction
+
+Opcode: `0x87`
+
+Description: \
+Sign extend the lower 32-bit value in `dst_reg` to 64-bit and store into
+`dst_reg`. This instruction discards and does not consider any value in the
+upper 32-bits of the `dst_reg`.
+
+Input Constraints: \
+$\mathtt{dst\_reg} \neq \mathtt{r10}$
+
+Operation:
+```
+if dst_reg[31] = 0 {
+  dst_reg[63:32] := 0
+} else {
+  dst_reg[63:32] := 1
+}
+```
+---
+
+The changes to existing instructions is as follows:
+
+---
+
+### `OR64_IMM` - Bitwise Or 64-bit Immediate
+Opcode: `0x47`
+
+Description: \
+Zero-extend `imm` to 64-bits. Perform bitwise or on the zero-extended immediate
+with `dst_reg`. Store this value in dst_reg.
+
+Input Constraints: \
+$\mathtt{dst\_reg} \neq \mathtt{r10}$
+
+Operation:
+```
+dst_reg := dst_reg | ZeroExtend(imm)
+```
+
+---
+
+### `AND64_IMM` - Bitwise And 64-bit Immediate
+Opcode: `0x57`
+
+Description: \
+Zero-extend `imm` to 64-bits. Perform bitwise and on the zero-extended immediate
+with `dst_reg`. Store this value in dst_reg.
+
+Input Constraints: \
+$\mathtt{dst\_reg} \neq \mathtt{r10}$
+
+Operation:
+```
+dst_reg := dst_reg & ZeroExtend(imm)
+```
+
+---
+
+### `XOR64_IMM` - Bitwise Xor 64-bit Immediate
+Opcode: `0xA7`
+
+Description: \
+Zero-extend `imm` to 64-bits. Perform bitwise xor on the zero-extended immediate
+with `dst_reg`. Store this value in dst_reg.
+
+Input Constraints: \
+$\mathtt{dst\_reg} \neq \mathtt{r10}$
+
+Operation:
+```
+dst_reg := dst_reg ^ ZeroExtend(imm)
+```
+
+---
+
+### `MOV64_IMM` - Move 64-bit Immediate
+Opcode: `0xB7`
+
+Description: \
+Zero-extend `imm` to 64-bits. Perform bitwise xor on the zero-extended immediate
+with `dst_reg`. Store this value in dst_reg.
+
+Input Constraints: \
+$\mathtt{dst\_reg} \neq \mathtt{r10}$
+
+Operation:
+```
+dst_reg := dst_reg ^ ZeroExtend(imm)
+```
+
+---
+
+## Impact
+This proposal affects changes to Program Runtime v2 and the tooling being built
+for developers. It does not affect developers directly, 
+
+## Security Considerations
+All clients must carefully implement the changes to the instruction set and
+should fuzz test and cross validate the changes.
+
+## Drawbacks
+
+This will require work from both the compiler teams and runtime teams to 
+implement within SBPFv2. The work 
+
+It will reuse the old NEG64 instruction opcode from SBPFv1 in SBPFv2. 
+
+## Backwards Compatibility 
+
+SBPFv2 is a new version of the SBPF ISA and does not require backwards 
+compatibility with SBPFv1.
+
+## Appendix 1: Functions for Instruction Operations
+
+### Zero Extension Function
+```
+ZeroExtend(x: u32) -> u64 {
+  y: u64 := 0
+  y[31:0] := x
+  return y
+}
+```

--- a/proposals/0087-explicit-sign-extension-in-sbpfv2.md
+++ b/proposals/0087-explicit-sign-extension-in-sbpfv2.md
@@ -13,7 +13,7 @@ feature: TBD
 ## Summary
 
 Add a sign extension instruction to SBPFv2 and replace implicit sign extension
-in certain SBPF instructions with zero extension. 
+on instruction outputs in certain SBPF instructions with zero extension.
 
 ## Motivation
 
@@ -54,9 +54,8 @@ The new instruction is specified as follows:
 Opcode: `0x87`
 
 Description: \
-Sign extend the lower 32-bit value in `dst_reg` to 64-bit and store into
-`dst_reg`. This instruction discards and does not consider any value in the
-upper 32-bits of the `dst_reg`.
+Sign extend the lower 32-bit value in `src_reg` to 64-bit and store into 
+`dst_reg`.
 
 Input Constraints: \
 $\mathtt{dst\_reg} \neq \mathtt{r10}$
@@ -64,6 +63,8 @@ $\mathtt{dst\_reg} \neq \mathtt{r10}$
 Operation:
 
 ```
+dst_reg[31:0] := src_reg[31:0]
+
 if dst_reg[31] = 0 {
   dst_reg[63:32] := 0
 } else {
@@ -77,13 +78,12 @@ The changes to existing instructions is as follows:
 
 ---
 
-### `OR64_IMM` - Bitwise Or 64-bit Immediate
+### `ADD32_IMM` - Bitwise Or 64-bit Immediate
 
 Opcode: `0x47`
 
 Description: \
-Zero-extend `imm` to 64-bits. Perform bitwise or on the zero-extended immediate
-with `dst_reg`. Store this value in dst_reg.
+Truncate Perform 32-bit wrapping integer addition on this and `dst_reg`. Store into `dst_reg`.
 
 Input Constraints: \
 $\mathtt{dst\\_reg} \neq \mathtt{r10}$
@@ -91,7 +91,7 @@ $\mathtt{dst\\_reg} \neq \mathtt{r10}$
 Operation:
 
 ```
-dst_reg := dst_reg | ZeroExtend(imm)
+dst_reg := Truncate(dst_reg) + imm
 ```
 
 ---
@@ -186,3 +186,25 @@ ZeroExtend(x: u32) -> u64 {
   return y
 }
 ```
+
+### Sign Extension Function 
+
+```
+SignExtend(x: u32) -> u64 {
+  y: u64 := 0
+  y[31:0] := x
+  if x[31] = 0 {
+    y[63:32] := 0
+  } else {
+    y[63:32] := 1
+  }
+
+  return y
+}
+```
+
+### Zero Upper Function
+ZeroUpper(x: u64) -> u64 {
+  x[63:32] := 0
+  return x
+}

--- a/proposals/0087-explicit-sign-extension-in-sbpfv2.md
+++ b/proposals/0087-explicit-sign-extension-in-sbpfv2.md
@@ -8,8 +8,6 @@ type: Core
 status: Draft
 created: 2023-11-14
 feature: TBD
-supersedes:
-extends:
 ---
 
 ## Summary

--- a/proposals/0087-explicit-sign-extension-in-sbpfv2.md
+++ b/proposals/0087-explicit-sign-extension-in-sbpfv2.md
@@ -34,6 +34,7 @@ NA
 NA
 
 ## Detailed Design
+
 The instruction set changes proposed are two fold: 
 
 1. Add a new instruction to SBPFv2 for explicit sign extension.
@@ -49,6 +50,7 @@ instructions.
 The new instruction is specified as follows:
 
 ---
+
 ### `SEXT64_REG` - Sign Extension 64-Bit Instruction
 
 Opcode: `0x87`
@@ -62,6 +64,7 @@ Input Constraints: \
 $\mathtt{dst\_reg} \neq \mathtt{r10}$
 
 Operation:
+
 ```
 if dst_reg[31] = 0 {
   dst_reg[63:32] := 0
@@ -69,6 +72,7 @@ if dst_reg[31] = 0 {
   dst_reg[63:32] := 1
 }
 ```
+
 ---
 
 The changes to existing instructions is as follows:
@@ -76,6 +80,7 @@ The changes to existing instructions is as follows:
 ---
 
 ### `OR64_IMM` - Bitwise Or 64-bit Immediate
+
 Opcode: `0x47`
 
 Description: \
@@ -86,6 +91,7 @@ Input Constraints: \
 $\mathtt{dst\_reg} \neq \mathtt{r10}$
 
 Operation:
+
 ```
 dst_reg := dst_reg | ZeroExtend(imm)
 ```
@@ -93,6 +99,7 @@ dst_reg := dst_reg | ZeroExtend(imm)
 ---
 
 ### `AND64_IMM` - Bitwise And 64-bit Immediate
+
 Opcode: `0x57`
 
 Description: \
@@ -103,6 +110,7 @@ Input Constraints: \
 $\mathtt{dst\_reg} \neq \mathtt{r10}$
 
 Operation:
+
 ```
 dst_reg := dst_reg & ZeroExtend(imm)
 ```
@@ -110,6 +118,7 @@ dst_reg := dst_reg & ZeroExtend(imm)
 ---
 
 ### `XOR64_IMM` - Bitwise Xor 64-bit Immediate
+
 Opcode: `0xA7`
 
 Description: \
@@ -120,6 +129,7 @@ Input Constraints: \
 $\mathtt{dst\_reg} \neq \mathtt{r10}$
 
 Operation:
+
 ```
 dst_reg := dst_reg ^ ZeroExtend(imm)
 ```
@@ -127,6 +137,7 @@ dst_reg := dst_reg ^ ZeroExtend(imm)
 ---
 
 ### `MOV64_IMM` - Move 64-bit Immediate
+
 Opcode: `0xB7`
 
 Description: \
@@ -137,6 +148,7 @@ Input Constraints: \
 $\mathtt{dst\_reg} \neq \mathtt{r10}$
 
 Operation:
+
 ```
 dst_reg := dst_reg ^ ZeroExtend(imm)
 ```
@@ -144,17 +156,19 @@ dst_reg := dst_reg ^ ZeroExtend(imm)
 ---
 
 ## Impact
+
 This proposal affects changes to Program Runtime v2 and the tooling being built
 for developers. It does not affect developers directly, 
 
 ## Security Considerations
+
 All clients must carefully implement the changes to the instruction set and
 should fuzz test and cross validate the changes.
 
 ## Drawbacks
 
 This will require work from both the compiler teams and runtime teams to 
-implement within SBPFv2. The work 
+implement within SBPFv2.
 
 It will reuse the old NEG64 instruction opcode from SBPFv1 in SBPFv2. 
 
@@ -166,6 +180,7 @@ compatibility with SBPFv1.
 ## Appendix 1: Functions for Instruction Operations
 
 ### Zero Extension Function
+
 ```
 ZeroExtend(x: u32) -> u64 {
   y: u64 := 0

--- a/proposals/0087-explicit-sign-extension-in-sbpfv2.md
+++ b/proposals/0087-explicit-sign-extension-in-sbpfv2.md
@@ -1,5 +1,5 @@
 ---
-simd: '0085'
+simd: '0087'
 title: Explicit Sign-Extension in SBPFv2
 authors:
   - Liam Heeger (@CantelopePeel, @lheeger-jump)

--- a/proposals/0087-explicit-sign-extension-in-sbpfv2.md
+++ b/proposals/0087-explicit-sign-extension-in-sbpfv2.md
@@ -86,7 +86,7 @@ Zero-extend `imm` to 64-bits. Perform bitwise or on the zero-extended immediate
 with `dst_reg`. Store this value in dst_reg.
 
 Input Constraints: \
-$\mathtt{dst\_reg} \neq \mathtt{r10}$
+$\mathtt{dst\\_reg} \neq \mathtt{r10}$
 
 Operation:
 

--- a/proposals/0087-explicit-sign-extension-in-sbpfv2.md
+++ b/proposals/0087-explicit-sign-extension-in-sbpfv2.md
@@ -2,7 +2,7 @@
 simd: '0087'
 title: Explicit Sign-Extension in SBPFv2
 authors:
-  - Liam Heeger (@CantelopePeel, @lheeger-jump)
+  - Liam Heeger (Jump)
 category: Standard
 type: Core
 status: Draft


### PR DESCRIPTION
This proposal adds a new sign extension instruction to SBPFv2 and removes implicit sign extension in some instructions under SBPFv2.