### PR TITLE
fix custom ci for metadata

### DIFF
--- a/.github/linter/customRules.ts
+++ b/.github/linter/customRules.ts
@@ -121,6 +121,8 @@ const requiredMetadata = {
 
 const optionalMetadata = {
   feature: {},
+  supersedes: {},
+  extends: {},
 }
 
 export const metadataSimdIsValid = {


### PR DESCRIPTION
Aligns CI with the template by adding `supersedes` and `extends` to the optional metadata.