### PR TITLE
SIMD-0106: Epoch Rewards Partition Data PDA

### DIFF
--- a/proposals/0106-paritioned-epoch-rewards-pda.md
+++ b/proposals/0106-paritioned-epoch-rewards-pda.md
@@ -7,7 +7,7 @@ category: Standard
 type: Core
 status: Draft
 created: 2024-01-17
-feature: (fill in with feature tracking issues once accepted)
+feature: https://github.com/solana-labs/solana/issues/32166
 extends: 0015
 ---
 

--- a/proposals/0106-paritioned-epoch-rewards-pda.md
+++ b/proposals/0106-paritioned-epoch-rewards-pda.md
@@ -73,6 +73,8 @@ seeds. Specifically: `[b"EpochRewards",b"PartitionData", &epoch.to_le_bytes()]`.
 The owning program will be the Sysvar program id:
 `Sysvar1111111111111111111111111111111111111`.
 
+The partition-data PDA will not be available to on-chain programs via syscall.
+
 Like traditional sysvars, the partitioned-rewards data PDAs should only be
 loadable as read-only. SIMD 0105 defines a method for demoting sysvar write
 locks, but depends on a list of addresses in code. If write-lock handling of

--- a/proposals/0106-paritioned-epoch-rewards-pda.md
+++ b/proposals/0106-paritioned-epoch-rewards-pda.md
@@ -71,9 +71,11 @@ struct PartitionData {
 }
 ```
 
-The address of this PDA should include some bytes to prevent griefing (eg.
-`b"EpochRewardsPartitionData"`) and the rewards distribution epoch number as a
-little-endian u64. The owning program should be the Stake Program.
+The address of this PDA will use some bytes -- to prevent griefing and namespace
+the PDAs -- and the rewards distribution epoch number as a little-endian u64 as
+seeds. Specifically: `[b"EpochRewards",b"PartitionData", &epoch.to_le_bytes()]`.
+The owning program should be the sysvar program id:
+`Sysvar1111111111111111111111111111111111111`.
 
 ## Impact
 

--- a/proposals/0106-paritioned-epoch-rewards-pda.md
+++ b/proposals/0106-paritioned-epoch-rewards-pda.md
@@ -47,10 +47,10 @@ None
 
 When partitioned rewards are calculated in the runtime (currently in the first
 block of the epoch when new-epoch operations -- like feature activations and
-leader schedule generation -- are processed), the runtime should populate a PDA
+leader schedule generation -- are processed), the runtime must populate a PDA
 that stores the partition data needed to recreate the hasher that returns the
-partition index for any address. This data comprises: the number of partitions,
-the parent blockhash, and the hasher kind. More specifically:
+partition index for any address. The data comprises: the number of partitions
+and parent blockhash. More specifically:
 
 ```rust
 // Version wrapper to allow future updates
@@ -67,7 +67,7 @@ enum HasherKind {
 
 // Data about rewards partitions for a particular epoch
 struct PartitionData {
-    num_partitions: usize, // little-endian unsigned 64-bit integer
+    num_partitions: u64, // little-endian unsigned 64-bit integer
     parent_blockhash: Hash, // byte-array of length 32
 }
 ```
@@ -75,7 +75,7 @@ struct PartitionData {
 The address of this PDA will use some bytes -- to prevent griefing and namespace
 the PDAs -- and the rewards distribution epoch number as a little-endian u64 as
 seeds. Specifically: `[b"EpochRewards",b"PartitionData", &epoch.to_le_bytes()]`.
-The owning program should be the Sysvar program id:
+The owning program will be the Sysvar program id:
 `Sysvar1111111111111111111111111111111111111`.
 
 ## Impact

--- a/proposals/0106-paritioned-epoch-rewards-pda.md
+++ b/proposals/0106-paritioned-epoch-rewards-pda.md
@@ -1,6 +1,6 @@
 ---
 simd: '0106'
-title: Partitioned Epoch Rewards PDA
+title: Epoch Rewards Partition Data PDA
 authors:
   - Tyera Eulberg
 category: Standard

--- a/proposals/0106-paritioned-epoch-rewards-pda.md
+++ b/proposals/0106-paritioned-epoch-rewards-pda.md
@@ -45,11 +45,12 @@ None
 
 ## Detailed Design
 
-When partitioned rewards are calculated in the runtime (currently during the
-first block of the epoch), the runtime should populate a PDA that stores the
-partition data needed to recreate the hasher that returns the partition index
-for any address. This data comprises: the number of partitions, the parent
-blockhash, and the hasher kind. More specifically:
+When partitioned rewards are calculated in the runtime (currently in the first
+block of the epoch when new-epoch operations -- like feature activations and
+leader schedule generation -- are processed), the runtime should populate a PDA
+that stores the partition data needed to recreate the hasher that returns the
+partition index for any address. This data comprises: the number of partitions,
+the parent blockhash, and the hasher kind. More specifically:
 
 ```rust
 // Version wrapper to allow future updates

--- a/proposals/0106-paritioned-epoch-rewards-pda.md
+++ b/proposals/0106-paritioned-epoch-rewards-pda.md
@@ -53,20 +53,22 @@ blockhash, and the hasher kind. More specifically:
 
 ```rust
 // Version wrapper to allow future updates
+// Variant serialized as little-endian unsigned 32-bit integer
 enum EpochRewardsPartitionDataVersion {
     V0(PartitionData),
 }
 
 // Extensible list of kinds of hashers used to generate partitions
+// Variant serialized as little-endian unsigned 32-bit integer
 enum HasherKind {
-    Sip13,
+    Sip13 = 0,
 }
 
 // Data about rewards partitions for a particular epoch
 struct PartitionData {
-    num_partitions: usize,
-    parent_blockhash: Hash,
-    hasher_kind: HasherKind,
+    num_partitions: usize, // little-endian unsigned 64-bit integer
+    parent_blockhash: Hash, // byte-array of length 32
+    hasher_kind: HasherKind, // little-endian unsigned 32-bit integer
 }
 ```
 

--- a/proposals/0106-paritioned-epoch-rewards-pda.md
+++ b/proposals/0106-paritioned-epoch-rewards-pda.md
@@ -45,13 +45,13 @@ None
 
 ## Detailed Design
 
-When partitioned rewards are calculated in the runtime (currently in the first
-block of the epoch when new-epoch operations -- like feature activations and
-leader schedule generation -- are processed), the runtime must populate a PDA
-that stores the partition data needed to recreate the hasher that returns the
-partition index for any address. The hasher for v0 partitioned rewards is
-SipHash 1-3. The data needed comprises: the number of partitions and parent
-blockhash. More specifically:
+When partitioned rewards populates the temporary `EpochRewards` sysvar --
+defined in SIMD 0015 as at the start of the first block of the epoch, before any
+transactions are processed -- the runtime must populate a PDA that stores the
+partition data needed to recreate the hasher that returns the partition index
+for any address. The hasher for v0 partitioned rewards is SipHash 1-3. The data
+needed comprises: the number of partitions and parent blockhash. More
+specifically:
 
 ```rust
 // Version wrapper to allow future updates

--- a/proposals/0106-paritioned-epoch-rewards-pda.md
+++ b/proposals/0106-paritioned-epoch-rewards-pda.md
@@ -49,7 +49,26 @@ When partitioned rewards are calculated in the runtime (currently during the
 first block of the epoch), the runtime should populate a PDA that stores the
 partition data needed to recreate the hasher that returns the partition index
 for any address. This data comprises: the number of partitions, the parent
-blockhash, and the hasher kind.
+blockhash, and the hasher kind. More specifically:
+
+```rust
+// Version wrapper to allow future updates
+enum EpochRewardsPartitionDataVersion {
+    V0(PartitionData),
+}
+
+// Extensible list of kinds of hashers used to generate partitions
+enum HasherKind {
+    Sip13,
+}
+
+// Data about rewards partitions for a particular epoch
+struct PartitionData {
+    num_partitions: usize,
+    parent_blockhash: Hash,
+    hasher_kind: HasherKind,
+}
+```
 
 The address of this PDA should include the current epoch number (which contains
 the distributions) as a little-endian u64, as well as some bytes to prevent

--- a/proposals/0106-paritioned-epoch-rewards-pda.md
+++ b/proposals/0106-paritioned-epoch-rewards-pda.md
@@ -59,7 +59,7 @@ enum EpochRewardsPartitionDataVersion {
 }
 
 // Extensible list of kinds of hashers used to generate partitions
-// Variant serialized as little-endian unsigned 32-bit integer
+// Mapping fn defines the HasherKind for each partition-data version
 enum HasherKind {
     Sip13 = 0,
 }
@@ -68,7 +68,6 @@ enum HasherKind {
 struct PartitionData {
     num_partitions: usize, // little-endian unsigned 64-bit integer
     parent_blockhash: Hash, // byte-array of length 32
-    hasher_kind: HasherKind, // little-endian unsigned 32-bit integer
 }
 ```
 

--- a/proposals/0106-paritioned-epoch-rewards-pda.md
+++ b/proposals/0106-paritioned-epoch-rewards-pda.md
@@ -70,10 +70,9 @@ struct PartitionData {
 }
 ```
 
-The address of this PDA should include the current epoch number (which contains
-the distributions) as a little-endian u64, as well as some bytes to prevent
-griefing (eg. `b"EpochRewardsPartitionData"`). The owning program should be the
-Stake Program.
+The address of this PDA should include some bytes to prevent griefing (eg.
+`b"EpochRewardsPartitionData"`) and the current epoch number as a little-endian
+u64. The owning program should be the Stake Program.
 
 ## Impact
 

--- a/proposals/0106-paritioned-epoch-rewards-pda.md
+++ b/proposals/0106-paritioned-epoch-rewards-pda.md
@@ -73,6 +73,12 @@ seeds. Specifically: `[b"EpochRewards",b"PartitionData", &epoch.to_le_bytes()]`.
 The owning program will be the Sysvar program id:
 `Sysvar1111111111111111111111111111111111111`.
 
+Like traditional sysvars, the partitioned-rewards data PDAs should only be
+loadable as read-only. SIMD 0105 defines a method for demoting sysvar write
+locks, but depends on a list of addresses in code. If write-lock handling of
+dynamically addressed sysvars like these PDAs seems needed in the future, a new
+proposal should be introduced.
+
 ## Impact
 
 The change in this proposal does increase the number of "forever" accounts that
@@ -85,11 +91,7 @@ scanning an unknown number of blocks.
 
 ## Security Considerations
 
-Like traditional sysvars, the partitioned-rewards data PDAs should only be
-loadable as read-only. SIMD 0105 defines a method for demoting sysvar write
-locks, but depends on a list of static addresses. If write-lock handling of
-dynamically addressed sysvars like these PDAs seems needed in the future, a new
-proposal should be introduced.
+None
 
 ## Backwards Compatibility
 

--- a/proposals/0106-paritioned-epoch-rewards-pda.md
+++ b/proposals/0106-paritioned-epoch-rewards-pda.md
@@ -90,8 +90,11 @@ scanning an unknown number of blocks.
 
 ## Security Considerations
 
-Like traditional sysvars, the new accounts should only be loadable as read-only.
-How this would be accomplished depends on the outcome of SIMD 0105.
+Like traditional sysvars, the partitioned-rewards data PDAs should only be
+loadable as read-only. SIMD 0105 defines a method for demoting sysvar write
+locks, but depends on a list of static addresses. If write-lock handling of
+dynamically addressed sysvars like these PDAs seems needed in the future, a new
+proposal should be introduced.
 
 ## Backwards Compatibility
 

--- a/proposals/0106-paritioned-epoch-rewards-pda.md
+++ b/proposals/0106-paritioned-epoch-rewards-pda.md
@@ -91,6 +91,7 @@ How this would be accomplished depends on the outcome of SIMD 0105.
 
 ## Backwards Compatibility
 
-Population of an account each epoch is a consensus-breaking change and must be
-activated with a feature gate. Since this is an extension of SIMD 0015, it
+Runtime-population of an account each epoch is a consensus-breaking change and
+must be activated with a feature gate. Since this is an extension of SIMD 0015
+and that feature gate has not yet been activated on any public clusters, it
 should be gated by the same feature id.

--- a/proposals/0106-paritioned-epoch-rewards-pda.md
+++ b/proposals/0106-paritioned-epoch-rewards-pda.md
@@ -73,8 +73,8 @@ struct PartitionData {
 ```
 
 The address of this PDA should include some bytes to prevent griefing (eg.
-`b"EpochRewardsPartitionData"`) and the current epoch number as a little-endian
-u64. The owning program should be the Stake Program.
+`b"EpochRewardsPartitionData"`) and the rewards distribution epoch number as a
+little-endian u64. The owning program should be the Stake Program.
 
 ## Impact
 

--- a/proposals/0106-paritioned-epoch-rewards-pda.md
+++ b/proposals/0106-paritioned-epoch-rewards-pda.md
@@ -49,20 +49,15 @@ When partitioned rewards are calculated in the runtime (currently in the first
 block of the epoch when new-epoch operations -- like feature activations and
 leader schedule generation -- are processed), the runtime must populate a PDA
 that stores the partition data needed to recreate the hasher that returns the
-partition index for any address. The data comprises: the number of partitions
-and parent blockhash. More specifically:
+partition index for any address. The hasher for v0 partitioned rewards is
+SipHash 1-3. The data needed comprises: the number of partitions and parent
+blockhash. More specifically:
 
 ```rust
 // Version wrapper to allow future updates
 // Variant serialized as little-endian unsigned 32-bit integer
 enum EpochRewardsPartitionDataVersion {
     V0(PartitionData),
-}
-
-// Extensible list of kinds of hashers used to generate partitions
-// Mapping fn defines the HasherKind for each partition-data version
-enum HasherKind {
-    Sip13 = 0,
 }
 
 // Data about rewards partitions for a particular epoch

--- a/proposals/0106-paritioned-epoch-rewards-pda.md
+++ b/proposals/0106-paritioned-epoch-rewards-pda.md
@@ -1,0 +1,78 @@
+---
+simd: '0106'
+title: Partitioned Epoch Rewards PDA
+authors:
+  - Tyera Eulberg
+category: Standard
+type: Core
+status: Draft
+created: 2024-01-17
+feature: (fill in with feature tracking issues once accepted)
+extends: 0015
+---
+
+## Summary
+
+Partitioned epoch rewards (SIMD 0015) will split epoch rewards distribution
+across multiple blocks at the start of an epoch. This extension of that SIMD
+proposes storing data about the rewards calculation and partitions in a sysvar
+account at a program-derived address (PDA), which can be queried by clients, or
+indeed within the runtime, to performantly identify the partition for the
+distribution to any particular address.
+
+## Motivation
+
+When we move to partitioned epoch rewards as described in the original SIMD, the
+only way to find the stake or voting rewards for a specific address will be to
+iterate through blocks at the beginning of each epoch, inspecting all the
+rewards. This is because the runtime does not persist information about how the
+rewards were partitioned; in fact, it does not even persist how many blocks the
+rewards distribution spans, so there is no way to predict how long it will take
+or how far through the epoch to go in finding a particular address.
+
+## Alternatives Considered
+
+An alternative to storing partition data in an on-chain account would be to
+record the necessary data in the ledger in some fashion. This could be a
+transaction that gets added to the block, a special RewardType, or metadata that
+gets stored on the node and then duplicated to long-term storage, like Bigtable.
+In fact, it is probably worthwhile to pursue this alternative as well, since it
+will enable finding rewards without access to snapshots or the running chain.
+
+## New Terminology
+
+None
+
+## Detailed Design
+
+When partitioned rewards are calculated in the runtime (currently during the
+first block of the epoch), the runtime should populate a PDA that stores the
+partition data needed to recreate the hasher that returns the partition index
+for any address. This data comprises: the number of partitions, the parent
+blockhash, and the hasher kind.
+
+The address of this PDA should include the current epoch number (which contains
+the distributions) as a little-endian u64, as well as some bytes to prevent
+griefing (eg. `b"EpochRewardsPartitionData"`). The owning program should be the
+Stake Program.
+
+## Impact
+
+The change in this proposal does increase the number of "forever" accounts that
+validators must store by one per epoch. However, the PDAs will be owned by the
+stake program, so could be adjusted or closed in the future by a feature-gated
+change to the Stake Program. Meanwhile, the change greatly improves the
+post-SIMD 0015 situation for clients trying to track stake or voting rewards,
+since they can use the data in the PDA to pull the correct partition directly,
+instead of scanning an unknown number of blocks.
+
+## Security Considerations
+
+Like traditional sysvars, the new accounts should only be loadable as read-only.
+How this would be accomplished depends on the outcome of SIMD 0105.
+
+## Backwards Compatibility
+
+Population of an account each epoch is a consensus-breaking change and must be
+activated with a feature gate. Since this is an extension of SIMD 0015, it
+should be gated by the same feature id.

--- a/proposals/0106-paritioned-epoch-rewards-pda.md
+++ b/proposals/0106-paritioned-epoch-rewards-pda.md
@@ -74,18 +74,18 @@ struct PartitionData {
 The address of this PDA will use some bytes -- to prevent griefing and namespace
 the PDAs -- and the rewards distribution epoch number as a little-endian u64 as
 seeds. Specifically: `[b"EpochRewards",b"PartitionData", &epoch.to_le_bytes()]`.
-The owning program should be the sysvar program id:
+The owning program should be the Sysvar program id:
 `Sysvar1111111111111111111111111111111111111`.
 
 ## Impact
 
 The change in this proposal does increase the number of "forever" accounts that
 validators must store by one per epoch. However, the PDAs will be owned by the
-stake program, so could be adjusted or closed in the future by a feature-gated
-change to the Stake Program. Meanwhile, the change greatly improves the
-post-SIMD 0015 situation for clients trying to track stake or voting rewards,
-since they can use the data in the PDA to pull the correct partition directly,
-instead of scanning an unknown number of blocks.
+Sysvar program, so could be adjusted or closed in the future by a feature-gated
+change to that program. Meanwhile, the change greatly improves the post-SIMD
+0015 situation for clients trying to track stake or voting rewards, since they
+can use the data in the PDA to pull the correct partition directly, instead of
+scanning an unknown number of blocks.
 
 ## Security Considerations
 


### PR DESCRIPTION
[Partitioned epoch rewards (SIMD 0015)](https://github.com/solana-foundation/solana-improvement-documents/blob/9143bf73ff9f50749bfd246e73e3fa61aff078be/proposals/0015-partitioned-epoch-reward-distribution.md) will split epoch rewards distribution across multiple blocks at the start of an epoch. This extension of that SIMD proposes storing data about the rewards calculation and partitions in a sysvar account at a program-derived address (PDA), which can be queried by clients, or indeed within the runtime, to performantly identify the partition for the distribution to any particular address.