### PR TITLE
SIMD-0118: Partitioned Epoch Rewards, amend/extend design

### DIFF
--- a/proposals/0015-partitioned-epoch-reward-distribution.md
+++ b/proposals/0015-partitioned-epoch-reward-distribution.md
@@ -5,9 +5,10 @@ authors:
   - Haoran Yi (Solana Labs)
 category: Standard
 type: Core
-status: Draft
+status: Accepted
 created: 2023-03-02
 feature: (fill in with feature tracking issues once accepted)
+superseded-by: '0118'
 ---
 
 ## Summary

--- a/proposals/0118-partitioned-epoch-reward-distribution.md
+++ b/proposals/0118-partitioned-epoch-reward-distribution.md
@@ -117,7 +117,8 @@ M = ((4096 - 1)+num_stake_accounts)/4096
 
 To safeguard against the number of stake accounts growing dramatically and
 overflowing the number of blocks in an epoch, the number of blocks is capped at
-10% of the total slots in an epoch.
+10% of the total slots in an epoch. If the block cap is reached, accounts per
+partition is allowed to surpass the 4,096 target.
 
 The [SipHash 1-3](https://www.aumasson.jp/siphash/siphash.pdf) pseudo-random
 function is used to hash stake account addresses efficiently and uniformly

--- a/proposals/0118-partitioned-epoch-reward-distribution.md
+++ b/proposals/0118-partitioned-epoch-reward-distribution.md
@@ -153,23 +153,30 @@ Prefixes indidate the offset of each field, and padding bytes are always zero.
 #[repr(C)] // C representation, 8-byte alignment
 struct EpochRewards{
    // whether the rewards period (calculation and distribution) is active
-   /* 0x00 */ active: bool, // byte. false: 0x00, true: 0x01
+   // byte. false: 0x00, true: 0x01
+   /* 0x00 */ active: bool,
 
-   /* 0x08 */ distribution_starting_block_height: u64, // little-endian unsigned 64-bit integer
+   // little-endian unsigned 64-bit integer
+   /* 0x08 */ distribution_starting_block_height: u64,
    
-   /* 0x10 */ num_partitions: u64, // little-endian unsigned 64-bit integer
+   // little-endian unsigned 64-bit integer
+   /* 0x10 */ num_partitions: u64,
    
-   /* 0x18 */ parent_blockhash: Hash, // byte-array of length 32
+   // byte-array of length 32
+   /* 0x18 */ parent_blockhash: Hash,
 
    // total points calculated for the current epoch, where points equals the sum
    // of delegated stake * credits observed for all delegations
-   /* 0x38 */ total_points: u128, // little-endian unsigned 128-bit integer
+   // little-endian unsigned 128-bit integer
+   /* 0x38 */ total_points: u128, 
 
    // total rewards for the current epoch, in lamports
-   /* 0x48 */ total_rewards: u64, // little-endian unsigned 64-bit integer
+   // little-endian unsigned 64-bit integer
+   /* 0x48 */ total_rewards: u64,
 
    // distributed rewards for the current epoch, in lamports
-   /* 0x50 */ distributed_rewards: u64, // little-endian unsigned 64-bit integer
+   // little-endian unsigned 64-bit integer
+   /* 0x50 */ distributed_rewards: u64, 
 }
 ```
 

--- a/proposals/0118-partitioned-epoch-reward-distribution.md
+++ b/proposals/0118-partitioned-epoch-reward-distribution.md
@@ -147,28 +147,29 @@ include: the parameters needed to recalculate the reward partitions, the total
 rewards to be distributed, and the amount of rewards distributed so far.
 
 The layout of `EpochRewards` sysvar is shown in the following pseudo code.
+Prefixes indidate the offset of each field, and padding bytes are always zero.
 
 ```
-#[repr(C)] // C representation, ie. 8-byte alignment
+#[repr(C)] // C representation, 8-byte alignment
 struct EpochRewards{
    // whether the rewards period (calculation and distribution) is active
-   active: bool, // byte. false: 0x00, true: 0x01
+   /* 0x00 */ active: bool, // byte. false: 0x00, true: 0x01
 
-   distribution_starting_block_height: u64, // little-endian unsigned 64-bit integer
+   /* 0x08 */ distribution_starting_block_height: u64, // little-endian unsigned 64-bit integer
    
-   num_partitions: u64, // little-endian unsigned 64-bit integer
+   /* 0x10 */ num_partitions: u64, // little-endian unsigned 64-bit integer
    
-   parent_blockhash: Hash, // byte-array of length 32
+   /* 0x18 */ parent_blockhash: Hash, // byte-array of length 32
 
    // total points calculated for the current epoch, where points equals the sum
    // of delegated stake * credits observed for all delegations
-   total_points: u128, // little-endian unsigned 128-bit integer
+   /* 0x38 */ total_points: u128, // little-endian unsigned 128-bit integer
 
    // total rewards for the current epoch, in lamports
-   total_rewards: u64, // little-endian unsigned 64-bit integer
+   /* 0x48 */ total_rewards: u64, // little-endian unsigned 64-bit integer
 
    // distributed rewards for the current epoch, in lamports
-   distributed_rewards: u64, // little-endian unsigned 64-bit integer
+   /* 0x50 */ distributed_rewards: u64, // little-endian unsigned 64-bit integer
 }
 ```
 

--- a/proposals/0118-partitioned-epoch-reward-distribution.md
+++ b/proposals/0118-partitioned-epoch-reward-distribution.md
@@ -211,10 +211,10 @@ are in progress in order to prevent any changes interfering with reward
 distribution.
 
 Therefore, the Stake Program needs access to a syscall which reports whether the
-distribution phase is active. This new syscall `sol_get_epoch_rewards_status`
-should report the value of `EpochRewards::active`. All Stake Program
+distribution phase is active. This new syscall `sol_get_epoch_rewards_sysvar`
+should return the values of the `EpochRewards` sysvar. All Stake Program
 instructions that mutate stake data or debit stake balances must be disabled
-when `sol_get_epoch_rewards_status` is true.
+when `EpochRewards::active` is true.
 
 Any transaction that attempts to invoke such an instruction will fail with this
 new error code:
@@ -225,8 +225,9 @@ StakeError {
 }
 ```
 
-Other users can access the `sol_get_epoch_rewards_status` to determine the
-distribution-phase status from within the SVM.
+Other users can access the `active` field from the
+`sol_get_epoch_rewards_sysvar` syscall to determine the distribution-phase
+status from within the SVM.
 
 ## Impact
 

--- a/proposals/0118-partitioned-epoch-reward-distribution.md
+++ b/proposals/0118-partitioned-epoch-reward-distribution.md
@@ -1,13 +1,16 @@
 ---
-simd: '0015'
+simd: '0118'
 title: Partitioned Epoch Rewards Distribution
 authors:
-  - Haoran Yi (Solana Labs)
+  - Haoran Yi (Anza)
+  - Justin Starry (Anza)
+  - Tyera Eulberg (Anza)
 category: Standard
 type: Core
 status: Draft
-created: 2023-03-02
+created: 2024-02-16
 feature: (fill in with feature tracking issues once accepted)
+supersedes: 0015
 ---
 
 ## Summary

--- a/proposals/0118-partitioned-epoch-reward-distribution.md
+++ b/proposals/0118-partitioned-epoch-reward-distribution.md
@@ -238,9 +238,9 @@ epoch rewarding phase.
 The first impact is that stake accounts will see their rewards being credited a
 few blocks later in the epoch than before.
 
-The second impact is that users will not be able to update their stakes during
-the epoch reward phases, and will have to wait until the end of the epoch
-reward period to make any changes.
+The second impact is that users will only be able to credit their stake accounts
+during the epoch reward phase. Any other updates will have to wait until the end
+of the phase.
 
 Nonetheless, the overall amount of time that the user must wait before
 receiving and updating their stake rewards should be roughly equivalent to what
@@ -258,8 +258,12 @@ beta today.
 While the proposed new approach does impact and modify various components of
 the validators, it does not alter the economics of the reward system.
 
-If all the changes are implemented correctly and tested fully, there are no
-security issues.
+Reward distribution relies on restricting any lamport debit or state changes for
+stake accounts until distribution is completed.
+
+The initial reward calculation and reward-distribution progress should be
+recoverable from snapshots produced during the reward distribution period to
+avoid consensus failure.
 
 
 ## Backwards Compatibility

--- a/proposals/0118-partitioned-epoch-reward-distribution.md
+++ b/proposals/0118-partitioned-epoch-reward-distribution.md
@@ -1,10 +1,7 @@
 ---
 simd: '0118'
 title: Partitioned Epoch Rewards Distribution
-authors:
-  - Haoran Yi (Anza)
-  - Justin Starry (Anza)
-  - Tyera Eulberg (Anza)
+authors: Haoran Yi (Anza), Justin Starry (Anza), Tyera Eulberg (Anza)
 category: Standard
 type: Core
 status: Draft

--- a/proposals/0118-partitioned-epoch-reward-distribution.md
+++ b/proposals/0118-partitioned-epoch-reward-distribution.md
@@ -10,7 +10,7 @@ type: Core
 status: Draft
 created: 2024-02-16
 feature: (fill in with feature tracking issues once accepted)
-supersedes: 0015
+supersedes: '0015'
 ---
 
 ## Summary
@@ -170,8 +170,8 @@ The layout of `EpochRewards` sysvar is shown in the following pseudo code.
 
 ```
 struct EpochRewards{
-   // whether rewards distribution is active
-   active: bool, // byte
+   // whether the rewards period (calculation and distribution) is active
+   active: bool, // byte. false: 0x00, true: 0x01
 
    distribution_starting_block_height: u64, // little-endian unsigned 64-bit integer
    
@@ -215,7 +215,7 @@ distribution.
 Therefore, the Stake Program needs access to a syscall which reports whether the
 distribution phase is active. This new syscall `sol_get_epoch_rewards_status`
 should report the value of `EpochRewards::active`. All Stake Program
-instructions that mutate stake data or debit stake balances should be disabled
+instructions that mutate stake data or debit stake balances must be disabled
 when `sol_get_epoch_rewards_status` is true.
 
 Any transaction that attempts to invoke such an instruction will fail with this

--- a/proposals/0118-partitioned-epoch-reward-distribution.md
+++ b/proposals/0118-partitioned-epoch-reward-distribution.md
@@ -147,7 +147,7 @@ include: the parameters needed to recalculate the reward partitions, the total
 rewards to be distributed, and the amount of rewards distributed so far.
 
 The layout of `EpochRewards` sysvar is shown in the following pseudo code.
-Prefixes indidate the offset of each field, and padding bytes are always zero.
+Prefixes indicate the offset of each field, and padding bytes are always zero.
 
 ```
 #[repr(C)] // C representation, 8-byte alignment

--- a/proposals/0118-partitioned-epoch-reward-distribution.md
+++ b/proposals/0118-partitioned-epoch-reward-distribution.md
@@ -94,9 +94,11 @@ distribution during rewarding phases.
 ### Rewards Calculation
 
 The reward calculation will be performed at the first block of the epoch, block
-height `X`. Once the full rewards are calculated, the rewards will be
-partitioned into distribution chunks stored in the bank, which will then be
-distributed during the `reward distribution` phase.
+height `X`. (Some documentation on how rewards are calculated is available
+[here](https://docs.solanalabs.com/consensus/stake-delegation-and-rewards#basics).)
+Once the full rewards are calculated, the rewards will be partitioned into
+distribution chunks stored in the bank, which will then be distributed during
+the `reward distribution` phase.
 
 To ensure that each block distributes a subset of the rewards in a
 deterministic manner for the current epoch, while also randomizing the

--- a/proposals/0118-partitioned-epoch-reward-distribution.md
+++ b/proposals/0118-partitioned-epoch-reward-distribution.md
@@ -208,15 +208,18 @@ current block height can be discarded.
 
 ### Restrict Stake Account Mutation
 
-The stake accounts need to be preserved in credit-only state while distributions
-are in progress in order to prevent any changes interfering with reward
-distribution.
+In order to ensure partition recalculations will be the same across the
+distribution period, the number and addresses of stake accounts, as well as
+stake-delegation amounts, must remain unchanged. There are existing use-cases
+for crediting stake accounts at epoch boundaries; so as to not disrupt these
+credits, but otherwise take the most conservative approach, account credits will
+be the only stake-account changes permitted during distribution.
 
-Therefore, the Stake Program needs access to a syscall which reports whether the
-distribution phase is active. This new syscall `sol_get_epoch_rewards_sysvar`
-should return the values of the `EpochRewards` sysvar. All Stake Program
-instructions that mutate stake data or debit stake balances must be disabled
-when `EpochRewards::active` is true.
+To limit permissible actions, the Stake Program needs access to a syscall which
+reports whether the distribution phase is active. This new syscall
+`sol_get_epoch_rewards_sysvar` should return the values of the `EpochRewards`
+sysvar. All Stake Program instructions that mutate stake data or debit stake
+balances must be disabled when `EpochRewards::active` is true.
 
 Any transaction that attempts to invoke such an instruction will fail with this
 new error code:

--- a/proposals/0118-partitioned-epoch-reward-distribution.md
+++ b/proposals/0118-partitioned-epoch-reward-distribution.md
@@ -219,7 +219,7 @@ To limit permissible actions, the Stake Program needs access to a syscall which
 reports whether the distribution phase is active. This new syscall
 `sol_get_epoch_rewards_sysvar` should return the values of the `EpochRewards`
 sysvar. All Stake Program instructions that mutate stake data or debit stake
-balances must be disabled when `EpochRewards::active` is true.
+account `lamports` balances must be disabled when `EpochRewards::active` is true.
 
 Any transaction that attempts to invoke such an instruction will fail with this
 new error code:

--- a/proposals/0118-partitioned-epoch-reward-distribution.md
+++ b/proposals/0118-partitioned-epoch-reward-distribution.md
@@ -1,0 +1,246 @@
+---
+simd: '0015'
+title: Partitioned Epoch Rewards Distribution
+authors:
+  - Haoran Yi (Solana Labs)
+category: Standard
+type: Core
+status: Draft
+created: 2023-03-02
+feature: (fill in with feature tracking issues once accepted)
+---
+
+## Summary
+
+A new way to distribute epoch rewards across multiple blocks is proposed to
+address the current performance problems associated with epoch reward
+distribution in a first block of a new epoch.
+
+## Motivation
+
+The distribution of epoch rewards at the start block of an epoch becomes a
+significant bottleneck due to the rising number of stake accounts and voting
+nodes on the network.
+
+To address this bottleneck, we propose a new approach for distributing the
+epoch rewards over multiple blocks.
+
+## New Terminology
+
+   - rewards calculation: calculate the epoch rewards for all active stake
+     accounts
+
+   - rewards distribution: distribute the epoch rewards for the active stake
+     accounts
+
+## Alternatives Considered
+
+We have discussed the following alternative approaches.
+
+1. Simply set a threshold on stake balance, and limit the epoch rewards to the
+   accounts with stake balance above the threshold. This will effectively
+   reduce the number of stake rewards to be distributed, and reduce reward
+   distribution time at the epoch boundary. However, this will impact stake
+   accounts with small balance. To receive rewards, the small stake accounts
+   will be forced to join stake pools, which some may be hesitant to do.
+
+2. Handle reward distributions through transactions with specialized native
+   reward programs. While this approach is optimal, it requires significant
+   modifications and doesn't align with the current reward code.
+
+3. A completely asynchronous epoch rewards calculation and distribution, in
+   which both reward computation and rewards distribution are asynchronous.
+   This is the most general approach. However, it is also the most complex
+   approach. The reward computation states would have to be maintained across
+   multiple blocks. The transition between the reward calculation and reward
+   distribution would need to be synchronized across the cluster. And cluster
+   restart during reward computation would have to be handled specially.
+
+4. An other approach is similar to the current proposal with additional
+   per-block reward reserve sysvar accounts. Those sysvar accounts are
+   introduced to track and verify the rewards distributed per block. The
+   per-block reward reserve sysvar accounts add additional checks and safety
+   for reward distribution. However, they also add addition cost to block
+   processing, especially for the first block in the epoch. The first block is
+   already computationally heavily - it is responsible for processing all the
+   reward computation. The additional cost of those sysvars puts more burden
+   onto that block and hurt the timing for it.
+
+## Detailed Design
+
+The major bottleneck for epoch reward distribution is to distribute rewards to
+stake accounts. At the time of writing, there are approximately 550K active
+stake accounts and 1.5K vote accounts on Solana Mainnet Beta. Given the
+relatively small number of vote accounts, it makes sense to keep vote rewards
+distribution mechanism unchanged. They can still be distributed efficiently at
+the first block of the epoch boundary. This reduces the impact of rewards for
+vote account and also simplifies the overall changes. It also lets us focus on
+solving the primary bottleneck - Stake Rewards. Only Stake rewards are going to
+be distributed out over multiple blocks.
+
+In the new stake rewards distribution approach, we will separate the
+computation of rewards from the actual distribution of rewards at the epoch
+boundary by dividing the process into two distinct phases:
+
+   1. rewards calculation phase - during which the epoch rewards for all
+      activate stake accounts are computed and distribution chunks are scheduled.
+
+   1. rewards distribution phase - during which the calculated epoch rewards
+      for the active stake accounts are distributed.
+
+To help maintain the total capital balance and track/verify the reward
+distribution during rewarding phases, a new sysvar account, `EpochRewards`, is
+proposed. The `EpochRewards` sysvar holds the balance of the rewards that are
+pending for distribution.
+
+
+### Rewards Calculation
+
+Reward calculation phase computes all the rewards that need to be distributed
+for the active stake accounts, and partitions the reward into a number of
+chunks for distribution in the next phase.
+
+Currently, on Solana Mainnet Beta with ~550K active stake accounts, it shows
+that epoch reward calculation takes around 10 seconds on average. This will
+make it impossible to perform rewards computation synchronous within one block.
+
+However, there are quite a few promising optimizations that can cut down the
+reward computation time. An experiment for reward calculation optimization
+(https://github.com/solana-labs/solana/pull/31193) showed that we can cut the
+reward calculation time plus vote reward distribution time to around 1s. This
+makes synchronous reward computation and asynchronous reward distribution a
+feasible approach. We also believe that there is still more rooms for more
+optimization to further cut down the above timing.
+
+Therefore, the following design is based on the above optimization. The
+reward calculation will be performed at the first block of the epoch. Once the
+full rewards are calculated, the rewards will be partitioned into distribution
+chunks stored in the bank, which will then be distributed during the `reward
+distribution` phase.
+
+To ensure that each block distributes a subset of the rewards in a
+deterministic manner for the current epoch, while also randomizing the
+distribution across different epochs, the partitioning of all rewards will be
+done as follows.
+
+The reward results are sorted by Stake Account address, and randomly shuffled
+with a fast `rng` seeded by current epoch. The shuffled reward results are then
+divided into `M` chunks. This process will ensure that the reward distribution
+is deterministic for the current epoch, while also introducing a degree of
+randomness between epochs.
+
+To minimize the impact on block processing time during the reward distribution
+phase, a total of 4,096 accounts will be distributed per block. The total
+number of blocks needed to distributed rewards is given by the following
+formula to avoid using floating point value arithmetic:
+
+```
+M = ((4096 - 1)+num_stake_accounts)/4096
+```
+
+### `EpochRewards` Sysvar Account
+
+`EpochRewards` sysvar account records the total rewards and the amount of
+distributed rewards for the current epoch internally. And the account balance
+reflects the amount of pending rewards to distribute.
+
+The layout of `EpochRewards` sysvar is shown in the following pseudo code.
+
+```
+struct RewardRewards{
+   // total rewards for the current epoch, in lamports
+   total_rewards: u64,
+
+   // distributed rewards for  the current epoch, in lamports
+   distributed_rewards: u64,
+
+   // distribution of all staking rewards for the current
+   // epoch will be completed before this block height
+   distribution_complete_block_height: u64,
+}
+```
+
+The `EpochRewards` sysvar is created at the start of the first block of the
+epoch (before any transactions are processed), as both the total epoch rewards
+and vote account rewards become available at this time. The
+`distributed_reward_in_lamport` field is updated per reward distribution for
+each block in the reward distribution phase.
+
+Once all rewards have been distributed, the balance of the `EpochRewards`
+account MUST be reduced to `0` (or something has gone wrong). For safety, any
+extra lamports in `EpochRewards` accounts will be burned after reward
+distribution phase, and the sysvar account will be deleted. Because of the
+lifetime of `EpochRewards` sysvar coincides with the reward distribution
+interval, user can explicitly query the existence of this sysvar to determine
+whether a block is in reward interval. Therefore, no new RPC method for reward
+interval is needed.
+
+### Reward Distribution
+
+Reward distribution phase happens after reward computation phase, which starts
+after the first block in the epoch for this proposal. It lasts for `M` blocks.
+Each of the `M` blocks is responsible for distributing the reward from one
+partition of the rewards from the `EpochRewards` sysvar account.
+
+Before each reward distribution, the `EpochRewards` account's `balance` is
+checked to make sure there is enough balance to distribute the reward. After a
+reward is distributed, the balance in `EpochRewards` account is decreased by the
+amount of the reward that was distributed.
+
+### Restrict Stake Account Access
+
+To avoid the complexity and potential rewards in unexpected stake accounts,
+the stake program is disabled during the epoch reward distribution period.
+
+Any transaction that invokes staking program during this period will fail with
+a new unique error code - `StakeProgramUnavailable`.
+
+That means all updates to stake accounts have to wait until the rewards
+distribution finishes.
+
+Because different stake accounts are receiving the rewards at different blocks,
+on-chain programs, which depends on the rewards of stakes accounts during the
+reward period, may get into partial epoch reward state. To prevent this from
+happening, loading stake accounts from on-chain programs during reward period
+will be disabled. However, reading the stake account through RPC will still be
+available.
+
+
+## Impact
+
+There are the two main impacts of the changes to stake accounts during the
+epoch rewarding phase.
+
+The first impact is that stake accounts will see their rewards being credited a
+few blocks later in the epoch than before.
+
+The second impact is that users will not be able to update their stakes during
+the epoch reward phases, and will have to wait until the end of the epoch
+reward period to make any changes.
+
+Nonetheless, the overall amount of time that the user must wait before
+receiving and updating their stake rewards should be roughly equivalent to what
+they are now experiencing on the current mainnet beta, since the prolonged
+first block time at the epoch boundary effectively obstructs the user's access
+to those stake accounts during that time.
+
+Another advantage with the new approach is that all non-staking transactions
+will continue to be processed, while those transactions are blocked on mainnet
+beta today.
+
+
+## Security Considerations
+
+While the proposed new approach does impact and modify various components of
+the validators, it does not alter the economics of the reward system.
+
+If all the changes are implemented correctly and tested fully, there are no
+security issues.
+
+
+## Backwards Compatibility
+
+This is a breaking change.  The new epoch calculation and distribution approach
+will not be compatible with the old approach.
+
+## Open Questions

--- a/proposals/0118-partitioned-epoch-reward-distribution.md
+++ b/proposals/0118-partitioned-epoch-reward-distribution.md
@@ -112,11 +112,11 @@ makes synchronous reward computation and asynchronous reward distribution a
 feasible approach. We also believe that there is room for more optimization to
 further cut down the above timing.
 
-Therefore, the following design is based on the above optimization. The
-reward calculation will be performed at the first block of the epoch. Once the
-full rewards are calculated, the rewards will be partitioned into distribution
-chunks stored in the bank, which will then be distributed during the `reward
-distribution` phase.
+Therefore, the following design is based on the above optimization. The reward
+calculation will be performed at the first block of the epoch, block height `X`.
+Once the full rewards are calculated, the rewards will be partitioned into
+distribution chunks stored in the bank, which will then be distributed during
+the `reward distribution` phase.
 
 To ensure that each block distributes a subset of the rewards in a
 deterministic manner for the current epoch, while also randomizing the
@@ -189,7 +189,8 @@ epoch (before any transactions are processed), as both the total epoch rewards
 and vote account rewards become available at this time. The
 `distributed_rewards` field is updated per reward distribution for each block in
 the reward distribution phase. The `active` field is set to false after the last
-partition is distributed (and `total_rewards == distributed_rewards`).
+partition is distributed (and `total_rewards == distributed_rewards`), ie.
+before processing transactions in block at height `X + M`.
 
 #### Booting from Snapshot
 

--- a/proposals/0118-partitioned-epoch-reward-distribution.md
+++ b/proposals/0118-partitioned-epoch-reward-distribution.md
@@ -166,6 +166,7 @@ rewards to be distributed, and the amount of rewards distributed so far.
 The layout of `EpochRewards` sysvar is shown in the following pseudo code.
 
 ```
+#[repr(C)] // C representation, ie. 8-byte alignment
 struct EpochRewards{
    // whether the rewards period (calculation and distribution) is active
    active: bool, // byte. false: 0x00, true: 0x01

--- a/proposals/0118-partitioned-epoch-reward-distribution.md
+++ b/proposals/0118-partitioned-epoch-reward-distribution.md
@@ -151,33 +151,33 @@ The layout of `EpochRewards` sysvar is shown in the following pseudo code.
 Prefixes indicate the offset of each field, and padding bytes are always zero.
 
 ```
-#[repr(C)] // C representation, 8-byte alignment
+#[repr(C, align(16))] // C representation, 16-byte alignment
 struct EpochRewards{
-   // whether the rewards period (calculation and distribution) is active
-   // byte. false: 0x00, true: 0x01
-   /* 0x00 */ active: bool,
-
    // little-endian unsigned 64-bit integer
-   /* 0x08 */ distribution_starting_block_height: u64,
+   /* 0x00 */ distribution_starting_block_height: u64,
    
    // little-endian unsigned 64-bit integer
-   /* 0x10 */ num_partitions: u64,
+   /* 0x08 */ num_partitions: u64,
    
    // byte-array of length 32
-   /* 0x18 */ parent_blockhash: Hash,
+   /* 0x10 */ parent_blockhash: Hash,
 
    // total points calculated for the current epoch, where points equals the sum
    // of delegated stake * credits observed for all delegations
    // little-endian unsigned 128-bit integer
-   /* 0x38 */ total_points: u128, 
+   /* 0x30 */ total_points: u128, 
 
    // total rewards for the current epoch, in lamports
    // little-endian unsigned 64-bit integer
-   /* 0x48 */ total_rewards: u64,
+   /* 0x40 */ total_rewards: u64,
 
    // distributed rewards for the current epoch, in lamports
    // little-endian unsigned 64-bit integer
-   /* 0x50 */ distributed_rewards: u64, 
+   /* 0x48 */ distributed_rewards: u64, 
+
+   // whether the rewards period (calculation and distribution) is active
+   // byte. false: 0x00, true: 0x01
+   /* 0x50 */ active: bool,
 }
 ```
 

--- a/proposals/0118-partitioned-epoch-reward-distribution.md
+++ b/proposals/0118-partitioned-epoch-reward-distribution.md
@@ -136,7 +136,8 @@ I = (M * stake_address_hash) / 2^64
 
 The reward distribution phase happens after the reward computation phase, ie.
 during the second block in the epoch as per the current design. It lasts for `M`
-blocks (see previous section).
+blocks (see previous section). Rewards distribution for each block occurs before
+transaction processing occurs.
 
 #### `EpochRewards` Sysvar Account
 
@@ -184,9 +185,10 @@ The `EpochRewards` sysvar is repopulated at the start of the first block of the
 epoch (before any transactions are processed), as both the total epoch rewards
 and vote account rewards become available at this time. The
 `distributed_rewards` field is updated per reward distribution for each block in
-the reward distribution phase. The `active` field is set to false after the last
-partition is distributed (and `total_rewards == distributed_rewards`), ie.
-before processing transactions in block at height `X + M`.
+the reward distribution phase (before transaction processing). The `active`
+field is set to false after the last partition is distributed (and
+`total_rewards == distributed_rewards`), ie. before processing transactions in
+block at height `X + M`.
 
 #### Booting from Snapshot
 


### PR DESCRIPTION
This SIMD supersedes SIMD-0015 with some new design elements.
I have begun by copying in the original SIMD so that the changes can be seen more easily in subsequent commits.

https://github.com/solana-foundation/solana-improvement-documents/pull/116 may be useful as a reference, as it describes the existing Labs implementation.