### PR TITLE
add: superseded-by frontmatter

### DIFF
--- a/.github/linter/customRules.ts
+++ b/.github/linter/customRules.ts
@@ -99,7 +99,7 @@ export const enforceMetadataStructure = {
     })
 
     Object.keys(frontMatter).forEach((key) => {
-      if (!(requiredMetadata as any)[key] && !(optionalMetadata as any)[key]) {
+      if (!(requiredMetadata as any)[key] && !optionalMetadata.includes(key)) {
         onError({
           lineNumber: 1,
           detail: `Front matter contains invalid metadata \`${key}\``,
@@ -119,11 +119,12 @@ const requiredMetadata = {
   created: {},
 }
 
-const optionalMetadata = {
-  feature: {},
-  supersedes: {},
-  extends: {},
-}
+const optionalMetadata = [
+  "feature",
+  "supersedes",
+  "superseded-by",
+  "extends",
+]
 
 export const metadataSimdIsValid = {
   names: ["front-matter-has-simd"],

--- a/XXXX-template.md
+++ b/XXXX-template.md
@@ -9,6 +9,8 @@ status: Draft
 created: (fill me in with today's date, YYYY-MM-DD)
 feature: (fill in with feature tracking issues once accepted)
 supersedes: (optional - fill this in if the SIMD supersedes a previous SIMD)
+superseded-by: (optional - fill this in if the SIMD is superseded by a subsequent
+ SIMD)
 extends: (optional - fill this in if the SIMD extends the design of a previous
  SIMD)
 ---


### PR DESCRIPTION
Frontmatter to denote what SIMD another SIMD was superseded by was needed to make it easy to understand what SIMDs take precedent. Added the optional frontmatter to template + CI.