### PR TITLE
SIMD-0127: Syscall: Get-Sysvar

### DIFF
--- a/proposals/0127-get-sysvar-syscall.md
+++ b/proposals/0127-get-sysvar-syscall.md
@@ -1,0 +1,180 @@
+---
+simd: '0127'
+title: sol_get_sysvar syscall
+authors:
+  - Richard Patel
+category: Standard
+type: Core
+status: Draft
+created: 2024-03-15
+---
+
+## Summary
+
+SIMD-0127 introduces the syscall `sol_get_sysvar` which allows BPF programs
+to retrieve any sysvar.
+
+New invariants are placed on the sysvar cache to enable safe retrieval.
+
+Existing syscalls to retrieve sysvars are henceforth considered obsolete.
+
+## Motivation
+
+Sysvars are special accounts that are implicitly modified by the runtime.
+Certain sysvars are essential for operation of the network.  For example, the
+system program reads the 'recent block hashes' sysvar to provide durable nonce
+functionality.
+
+Currently, programs can read sysvars can using one of these three methods:
+
+1. Via explicit account access by specifying the sysvar address in the list of
+   transaction accounts
+2. Via API calls to the sysvar cache (for native programs only)
+3. Via syscalls that copy the sysvar content to virtual machine memory
+   (for BPF programs only, does not work for all sysvars)
+
+Improvements to these APIs are motivated by the following reasons.
+
+### Allowing sysvar upgrades
+
+The function signature of a `sol_get_{...}_sysvar` syscall is as follows:
+
+```c
+uint64_t sol_get_example_sysvar( void * dest_addr );
+```
+
+When called, the syscall handler will copy the sysvar to the given memory
+location.  Notably, BPF programs do not inform the syscall handler of the
+expected size of the sysvar.  BPF programs thus effectively assume that the
+requested sysvars will forever have the same size.
+
+This prevents future upgrades that shrink or extend sysvars.
+
+### Syscall API fragmentation
+
+The following sysvars are currently accessible using syscalls:
+
+- `SysvarC1ock11111111111111111111111111111111` (via `sol_get_clock_sysvar`)
+- `SysvarEpochRewards1111111111111111111111111` (via `sol_get_epoch_rewards_sysvar`)
+- `SysvarEpochSchedu1e111111111111111111111111` (via `sol_get_epoch_schedule_sysvar`)
+- `SysvarFees111111111111111111111111111111111` (via `sol_get_fees_sysvar`)
+- `Sysvar1nstructions1111111111111111111111111` (indirectly via `sol_get_processed_sibling_instruction`)
+- `SysvarLastRestartS1ot1111111111111111111111` (via `sol_get_last_restart_slot`)
+- `SysvarRent111111111111111111111111111111111` (via `sol_get_rent_sysvar`)
+
+BPF programs cannot access the following sysvars using syscalls.
+
+- `SysvarRecentB1ockHashes11111111111111111111`
+- `SysvarRewards111111111111111111111111111111`
+- `SysvarS1otHashes111111111111111111111111111`
+- `SysvarS1otHistory11111111111111111111111111`
+- `SysvarStakeHistory1111111111111111111111111`
+
+Introducing a new syscall for every new sysvar results in bloat of the syscall
+interface.  The aforementioned function signature that most sysvar getters use
+is also inefficient for large accounts.  Copying the entire sysvar to VM memory
+might consume excessive compute units (e.g. 16392 bytes for 'stake history').
+
+### Unblocking core BPF programs
+
+As per [SIMD-0088](./0088-enable-core-bpf-programs.md), an effort is underway
+to reduce code complexity of the Solana runtime by porting native programs to
+core BPF programs.
+
+These new programs target full compatibility with their predecessors to avoid
+introducing breaking API changes.  In some cases, native programs read a sysvar
+from the sysvar cache without requiring the user to include this sysvar in the
+transaction account list.  This happens in the stake program 'redelegate'
+instruction, for example.
+
+As a result, it is currently impossible to port certain native programs to core
+BPF programs.  Another factility to expose sysvars to the virtual machine is
+required.
+
+### Optimizing existing user programs
+
+Reading sysvars with the proposed syscall is expected to be more efficient than
+an explicit account access.  Removing explicit account accesses to sysvars will
+generally result in smaller transactions.  Reducing the amount of account data
+that is mapped into virtual machine memory may also yield cost savings.
+
+## Alternatives Considered
+
+Other mechanisms considered that provide sysvar data to BPF programs are as
+follows:
+
+### Sysvar-specific syscalls
+
+TODO
+
+### New memory regions
+
+TODO
+
+## Detailed Design
+
+### Sysvar Cache
+
+TODO
+
+### Restrictions on sysvar data dependencies
+
+TODO
+
+### `sol_get_sysvar` syscalls
+
+TODO this is outdated
+
+```c
+/* sol_get_sysvar_size queries the serialized byte size of a sysvar.
+   It is equal to the length of the serialization of the sysvar value.
+   The sysvar value is taken in the sysvar cache.
+
+   sysvar_id points to the 32 byte address of the sysvar.
+
+   If a non-empty sysvar was found in the sysvar cache, returns the
+   byte size of that sysvar.
+
+   If the requested sysvar was not found, is corrupt, is
+   unsupported for the current feature set, or is zero size, returns 0.
+
+   This syscall aborts the transaction if (and only if):
+   - The compute budget was exhausted */
+
+uint64_t
+sol_get_sysvar_size( /* r1 */ void const * sysvar_id );
+
+/* sol_get_sysvar copies sysvar data to VM memory.
+
+   sysvar_id points to the 32 byte address of the sysvar.
+
+   A sysvar is valid if sol_get_sysvar_size(sysvar_id) returns non-zero.
+   If the sysvar is not valid, returns zero without writing to out.
+
+   The byte range [offset,offset+size) selects the range of data to be
+   copied. The sysvar data is the serialized value of the corresponding
+   sysvar cache entry.
+   The size of this sysvar data is returned by sol_get_sysvar_size.
+
+   Copies the sysvar data to [out,out+size) and returns 1 if the sysvar is valid.
+
+   This syscall aborts the transaction if:
+   - Range [out,out+size) is not writable
+   - The compute budget was exhausted */
+
+int
+sol_get_sysvar(
+  /* r1 */ void const * sysvar_id,
+  /* r2 */ uint8_t *    out,
+  /* r3 */ uint64_t     offset,
+  /* r4 */ uint64_t     size
+);
+```
+
+## Impact
+
+TODO
+
+## Security Considerations
+
+TODO

--- a/proposals/0127-get-sysvar-syscall.md
+++ b/proposals/0127-get-sysvar-syscall.md
@@ -185,9 +185,6 @@ in the Sysvar Cache.
 Unless specified otherwise, any new sysvars added to the Sysvar Cache in the
 future also become accessible through this syscall.
 
-Existing syscalls to fetch sysvar data will be deprecated in favor of the new
-unified syscall proposed herein.
-
 The supported list of sysvars for the proposed syscall will be as follows:
 
 - `SysvarC1ock11111111111111111111111111111111`
@@ -216,6 +213,15 @@ interface.
 Furthermore, it unblocks the efforts to give BPF programs more access to
 sysvar data, so on-chain programs gain the ability to read more sysvar data
 without increasing transaction size.
+
+One minor change is the behavior of verification of syscall availability for a
+given program. Currently, the availability of specific sysvar data can be
+verified by simply determining whether its corresponding syscall is available to
+the program during the verification step.
+
+With this change, even though the new unified syscall can be verified available
+during program verification, the actual availability of specific sysvar data is
+determined at runtime.
 
 ## Security Considerations
 

--- a/proposals/0127-get-sysvar-syscall.md
+++ b/proposals/0127-get-sysvar-syscall.md
@@ -165,7 +165,7 @@ Otherwise, the syscall writes the sysvar data to the virtual memory at
 
 ### Compute Unit Usage
 
-The syscall will always attempt to consume the same amount of CUs regardless of
+The syscall will always consume the same amount of CUs regardless of
 control flow.
 
 CU usage is proportional to the `length` parameter.

--- a/proposals/0127-get-sysvar-syscall.md
+++ b/proposals/0127-get-sysvar-syscall.md
@@ -8,6 +8,7 @@ category: Standard
 type: Core
 status: Draft
 created: 2024-03-15
+feature: (fill in with feature tracking issues once accepted)
 ---
 
 ## Summary
@@ -57,7 +58,7 @@ fragments of the data can be made accessible via calls like
 Additionally, as per [SIMD-0088](./0088-enable-core-bpf-programs.md), an effort
 is underway to reduce code complexity of the Solana runtime by porting native
 programs to Core BPF programs. These programs must be 100% backwards compatible,
-therefore requiring access to this sysvar data via syscalls and *not* via
+therefore requiring access to this sysvar data via syscalls and _not_ via
 providing the account directly. Requiring the account would break the programs'
 ABIs.
 
@@ -75,7 +76,7 @@ spirit, if a new sysvar is created, a new syscall must be created.
 
 Furthermore, if certain queries are requred by BPF programs - such as
 `SlotHashes::get_slot()` and `StakeHistory::get_entry()` - those single-element
-retrievals will *also* require new syscalls.
+retrievals will _also_ require new syscalls.
 
 It's worth noting that at the time of this writing, the work required for
 [SIMD-0088](./0088-enable-core-bpf-programs.md) will require at least five new
@@ -111,6 +112,10 @@ region each time a VM is created (currently one per transaction processed),
 causing a degradation in runtime performance and likely reducing compute
 by far less compared to the compute savings posed by this proposal.
 
+## New Terminology
+
+N/A.
+
 ## Detailed Design
 
 Defining one single `get` API to retrieve data from the sysvar cache can be used
@@ -136,7 +141,7 @@ Generally, the following cases would be handled with errors:
 
 - The sysvar data is unavailable.
 - The sysvar data is corrupt.
-- The provided offset or length would be out of bounds on the sysvar data. 
+- The provided offset or length would be out of bounds on the sysvar data.
 
 Sysvars themselves should have internal logic for understanding their own size
 and the size of their entries if they are a list-based data structure. With this
@@ -146,7 +151,7 @@ A list-based sysvar - say `SlotHashes` - could leverage this API like so:
 
 ```rust
 fn get(index: usize) -> SlotHash {
-  let length = size_of::<SlotHash>(); 
+  let length = size_of::<SlotHash>();
   let offset = index * length;
   syscall::get(offset, length)
 }
@@ -172,7 +177,7 @@ The syscall interface for sysvars should only support `get` as defined above.
 
 ## Impact
 
-As mentioned as partial motiviation for this proposal, the new syscall would
+As mentioned as partial motivation for this proposal, the new syscall would
 make changing and adding new sysvars in the future much easier, which would be
 positively impactful to contributors.
 
@@ -188,7 +193,6 @@ without increasing transaction size.
 This new syscall interface does increase the chances of improper management of
 bytes and offsets, which could throw critical errors.
 
-However, this can be mitigated in testing, and the upside for reducing the numbe
-of syscalls - thereby reducing the surface area for other critical bugs or
-explots - is a decent tradeoff.
-
+However, this can be mitigated in testing, and the upside for reducing the
+number of syscalls - thereby reducing the surface area for other critical bugs
+or exploits - is a worthy tradeoff.

--- a/proposals/0127-get-sysvar-syscall.md
+++ b/proposals/0127-get-sysvar-syscall.md
@@ -150,6 +150,7 @@ Generally, the following cases would be handled with errors:
 - The sysvar data is unavailable.
 - The sysvar data is corrupt.
 - The provided offset or length would be out of bounds on the sysvar data.
+- The provided destination address `var_addr` is invalid.
 
 Sysvars themselves should have internal logic for understanding their own size
 and the size of their entries if they are a list-based data structure. With this

--- a/proposals/0127-get-sysvar-syscall.md
+++ b/proposals/0127-get-sysvar-syscall.md
@@ -148,43 +148,12 @@ uint64_t sol_get_sysvar(
 If the following conditions are not met, this syscall will return an error:
 
 - The sysvar data is available to read.
-- The sysvsr data is not corrupt.
+- The sysvar data is not corrupt.
 - `offset` + `length` is in the range `[0, 2^64)`.
 - `var_addr` + `length` is in the range `[0, 2^64)`.
 - Each byte in the range starting at `var_addr` of size `length` is writable.
 
-Sysvars themselves should have internal logic for understanding their own size
-and the size of their entries if they are a list-based data structure. With this
-information, each sysvar can customize how it wishes to drive the `get` syscall.
-
-Any sysvar that wishes to offer a more robust API would then be responsible for
-defining such an interface, rather than pushing that burden onto the syscall
-interface. For example, `SlotHashes` could offer something like the following:
-
-Any additionally complex methods - such as binary searches - should be left to
-the on-chain program to implement locally. These should not be made available to
-BPF programs via the sysvar interface.
-
-The syscall interface for sysvars should only support `get` as defined above.
-
 ### Supported Sysvars
-
-Currently, the following sysvars are available to BPF programs:
-
-- `SysvarC1ock11111111111111111111111111111111` (via `sol_get_clock_sysvar`)
-- `SysvarEpochRewards1111111111111111111111111` (via `sol_get_epoch_rewards_sysvar`)
-- `SysvarEpochSchedu1e111111111111111111111111` (via `sol_get_epoch_schedule_sysvar`)
-- `SysvarFees111111111111111111111111111111111` (via `sol_get_fees_sysvar`)
-- `Sysvar1nstructions1111111111111111111111111` (indirectly via `sol_get_processed_sibling_instruction`)
-- `SysvarLastRestartS1ot1111111111111111111111` (via `sol_get_last_restart_slot`)
-- `SysvarRent111111111111111111111111111111111` (via `sol_get_rent_sysvar`)
-
-Currently, the following sysvars from the Sysvar Cache are _not_ available to
-BPF programs:
-
-- `SysvarS1otHashes111111111111111111111111111`
-- `SysvarS1otHistory11111111111111111111111111`
-- `SysvarStakeHistory1111111111111111111111111`
 
 The proposed unified syscall interface will support all non-deprecated sysvars
 in the Sysvar Cache.
@@ -192,7 +161,10 @@ in the Sysvar Cache.
 Unless specified otherwise, any new sysvars added to the Sysvar Cache in the
 future also become accessible through this syscall.
 
-The supported list is as follows:
+Existing syscalls to fetch sysvar data will be deprecated in favor of the new
+unified syscall proposed herein.
+
+The supported list of sysvars for the proposed syscall will be as follows:
 
 - `SysvarC1ock11111111111111111111111111111111`
 - `SysvarEpochRewards1111111111111111111111111`
@@ -203,8 +175,10 @@ The supported list is as follows:
 - `SysvarS1otHistory11111111111111111111111111`
 - `SysvarStakeHistory1111111111111111111111111`
 
-The existing individual syscalls for each supported sysvar will be deprecated in
-favor of the new unified syscall.
+Sysvar APIs at the SDK level are responsible for defining exactly how the data
+can be accessed using the new syscall. For example, multiple SDKs may choose to
+allow users to access one element from a list-based sysvar at a time, while only
+a few may offer lookups or binary searches on the data.
 
 ## Impact
 

--- a/proposals/0127-get-sysvar-syscall.md
+++ b/proposals/0127-get-sysvar-syscall.md
@@ -155,13 +155,15 @@ The syscall aborts the virtual machine if any of these conditions are true:
 - `var_addr + length` is not in `[0, 2^64)`.
 - Compute budget is exceeded.
 
-The syscall returns `1` if the sysvar is not present in the Sysvar Cache.
+All VM violations (above) are checked first, before attempting to return
+gracefully.
 
-The syscall returns `2` if `offset + length` is greater than the size of the
-sysvar.
+The syscall returns the following graceful codes:
 
-Otherwise, the syscall writes the sysvar data to the virtual memory at
-`var_addr` and returns `0`.
+- `2` if `offset + length` is greater than the length of the sysvar data.
+- `1` if the sysvar data is not present in the Sysvar Cache.
+- `0` if the process completed successfully and the requested sysvar data was
+  written to the virtual memory at `var_addr`.
 
 ### Compute Unit Usage
 

--- a/proposals/0127-get-sysvar-syscall.md
+++ b/proposals/0127-get-sysvar-syscall.md
@@ -155,13 +155,14 @@ The syscall aborts the virtual machine if any of these conditions are true:
 - `var_addr + length` is not in `[0, 2^64)`.
 - Compute budget is exceeded.
 
-All VM violations (above) are checked first, before attempting to return
-gracefully.
+All VM violations (above) are checked first, before to returning one of the
+following error codes. The following checks are completed in the order they
+appear below.
 
 The syscall returns the following graceful codes:
 
-- `2` if `offset + length` is greater than the length of the sysvar data.
-- `1` if the sysvar data is not present in the Sysvar Cache.
+- `2` if the sysvar data is not present in the Sysvar Cache.
+- `1` if `offset + length` is greater than the length of the sysvar data.
 - `0` if the process completed successfully and the requested sysvar data was
   written to the virtual memory at `var_addr`.
 

--- a/proposals/0127-get-sysvar-syscall.md
+++ b/proposals/0127-get-sysvar-syscall.md
@@ -145,12 +145,13 @@ uint64_t sol_get_sysvar(
 
 ```
 
-Generally, the following cases would be handled with errors:
+If the following conditions are not met, this syscall will return an error:
 
-- The sysvar data is unavailable.
-- The sysvar data is corrupt.
-- The provided offset or length would be out of bounds on the sysvar data.
-- The provided destination address `var_addr` is invalid.
+- The sysvar data is available to read.
+- The sysvsr data is not corrupt.
+- `offset` + `length` is in the range `[0, 2^64)`.
+- `var_addr` + `length` is in the range `[0, 2^64)`.
+- Each byte in the range starting at `var_addr` of size `length` is writable.
 
 Sysvars themselves should have internal logic for understanding their own size
 and the size of their entries if they are a list-based data structure. With this

--- a/proposals/0127-get-sysvar-syscall.md
+++ b/proposals/0127-get-sysvar-syscall.md
@@ -12,11 +12,9 @@ feature: (fill in with feature tracking issues once accepted)
 
 ## Summary
 
-This proposal outlines a new syscall interface, specifically pertaining to
-sysvars, to retrieve dynamic ranges of sysvar data without fully copying the
-entire data structure. As a result, the existing sysvar interface will remain
-backwards compatible and could also support new methods for querying sysvar
-data.
+This proposal outlines a new syscall interface for sysvars; one which can
+retrieve dynamic ranges of sysvar data without fully copying the entire data
+structure.
 
 With a unified syscall interface to handle retrieval of sysvar data, many
 existing syscalls will become obsolete, and the act of changing sysvar data
@@ -128,7 +126,6 @@ forward-facing sysvar interfaces to retrieve data from any sysvar.
  * Retrieves a slice of data from a sysvar and copies it to VM memory.
  *
  * @param sysvar_id The identifier of the sysvar to retrieve data from.
- *                  It should be a single byte representing the sysvar.
  * @param var_addr  VM memory address to copy the retrieved data to.
  * @param offset    The offset to start copying data from.
  * @param length    The length of data to copy, in bytes.
@@ -167,6 +164,45 @@ the on-chain program to implement locally. These should not be made available to
 BPF programs via the sysvar interface.
 
 The syscall interface for sysvars should only support `get` as defined above.
+
+### Supported Sysvars
+
+Currently, the following sysvars are available to BPF programs:
+
+- `SysvarC1ock11111111111111111111111111111111` (via `sol_get_clock_sysvar`)
+- `SysvarEpochRewards1111111111111111111111111` (via `sol_get_epoch_rewards_sysvar`)
+- `SysvarEpochSchedu1e111111111111111111111111` (via `sol_get_epoch_schedule_sysvar`)
+- `SysvarFees111111111111111111111111111111111` (via `sol_get_fees_sysvar`)
+- `Sysvar1nstructions1111111111111111111111111` (indirectly via `sol_get_processed_sibling_instruction`)
+- `SysvarLastRestartS1ot1111111111111111111111` (via `sol_get_last_restart_slot`)
+- `SysvarRent111111111111111111111111111111111` (via `sol_get_rent_sysvar`)
+
+Currently, the following sysvars from the Sysvar Cache are _not_ available to
+BPF programs:
+
+- `SysvarS1otHashes111111111111111111111111111`
+- `SysvarS1otHistory11111111111111111111111111`
+- `SysvarStakeHistory1111111111111111111111111`
+
+The proposed unified syscall interface will support all non-deprecated sysvars
+in the Sysvar Cache.
+
+Unless specified otherwise, any new sysvars added to the Sysvar Cache in the
+future also become accessible through this syscall.
+
+The supported list is as follows:
+
+- `SysvarC1ock11111111111111111111111111111111`
+- `SysvarEpochRewards1111111111111111111111111`
+- `SysvarEpochSchedu1e111111111111111111111111`
+- `SysvarLastRestartS1ot1111111111111111111111`
+- `SysvarRent111111111111111111111111111111111`
+- `SysvarS1otHashes111111111111111111111111111`
+- `SysvarS1otHistory11111111111111111111111111`
+- `SysvarStakeHistory1111111111111111111111111`
+
+The existing individual syscalls for each supported sysvar will be deprecated in
+favor of the new unified syscall.
 
 ## Impact
 


### PR DESCRIPTION
This proposal outlines a new syscall interface for sysvars; one which can
retrieve dynamic ranges of sysvar data without fully copying the entire data
structure.

With a unified syscall interface to handle retrieval of sysvar data, many
existing syscalls will become obsolete, and the act of changing sysvar data
layouts or adding new sysvars will involve much less overhead.

Sysvars are special accounts that are implicitly modified by the runtime.
Certain sysvars are essential for operation of the network, and many others are
used by on-chain programs for a wide range of use cases.

The sysvar API should be completely consistent, available to all BPF programs,
and capable of more easily handling changes in the future. The syscall API for
sysvars should be designed to serve a wide range of requests on sysvar data
without bloating the overall syscall interface.
