### PR TITLE
SIMD-0132: Dynamic Block Limits

### DIFF
--- a/proposals/0130-dynamic-block-limits.md
+++ b/proposals/0130-dynamic-block-limits.md
@@ -19,8 +19,8 @@ This proposal introduces dynamic adjustments to the compute unit (CU) limit of
 Solana blocks based on network utilization at the end of each epoch. If the
 average block utilization exceeds 75%, the CU limit will increase by 20%;
 if it falls below 25%, the limit will decrease by 20%. This mechanism aims to
-optimize network performance by adapting to actual demand without centralized
-or arbitrary adjustments.
+optimize network performance by adapting to demonstrated compute capacity
+without centralized decisions about limits and without voting.
 
 ## Motivation
 

--- a/proposals/0130-dynamic-block-limits.md
+++ b/proposals/0130-dynamic-block-limits.md
@@ -71,9 +71,6 @@ threshold if the network demonstrates that it can handle such compute and that t
 is demand for it. **It is important to not increase CU limits if there is no demand
 for it, as arbitrarily increasing the CU limit opens up a vector for validators
 to produce fat blocks that the rest of the network may struggle to replay.**
-Thus, the increase criteria can be summarized as follows: increase capacity if
-there is demonstrated capacity and demand for it **AND** if it does not threaten
-protocol liveness or degrade UX.
 
 The second metric is present to preserve protocol liveness and responsive UX. If
 the SVSL is above the target threshold, it means that there are nodes in the
@@ -81,9 +78,13 @@ supermajority that are struggling to replay and vote within the target latency.
 This threatens protocol liveness, as it can be an indicator of nodes within the
 supermajority not being able to catch up to the tip. Furthermore, vote slot
 latency is directly tied to the solana user experience; it can serve as a proxy
-metric for finalization time. Thus, the decrease criteria can be summarized as
-follows: decrease capacity if there is no demonstrated demand for it **OR** if
-the current limits are threatening protocol liveness or degrading UX.
+metric for finalization time.
+
+Thus, the increase criteria can be summarized as follows: increase capacity if
+there is demonstrated capacity and demand for it **AND** if it does not threaten
+protocol liveness or degrade UX. Similarly , the decrease criteria can be
+summarized as follows: decrease capacity if there is no demonstrated demand for
+it **OR** if the current limits are threatening protocol liveness or degrading UX.
 
 By setting thresholds at 75% and 25%, this proposal very roughly targets a 50%
 block utilization. It is important to recognize that validator hardware is

--- a/proposals/0130-dynamic-block-limits.md
+++ b/proposals/0130-dynamic-block-limits.md
@@ -13,58 +13,77 @@ extends: (optional - fill this in if the SIMD extends the design of a previous
  SIMD)
 ---
 
-# SIMD Proposal: Dynamic Block Limits
-
 ## Summary
 
-This proposal introduces dynamic adjustments to the compute unit (CU) limit of Solana blocks based on network utilization at the end of each epoch. If the average block utilization exceeds 75%, the CU limit will increase by 20%; if it falls below 25%, the limit will decrease by 20%. This mechanism aims to optimize network performance by adapting to actual demand without centralized or arbitrary adjustments.
+This proposal introduces dynamic adjustments to the compute unit (CU) limit of
+Solana blocks based on network utilization at the end of each epoch. If the
+average block utilization exceeds 75%, the CU limit will increase by 20%;
+if it falls below 25%, the limit will decrease by 20%. This mechanism aims to
+optimize network performance by adapting to actual demand without centralized
+or arbitrary adjustments.
 
 ## Motivation
 
-The goal of this proposal is to enhance the scalability and efficiency of the Solana network by dynamically adjusting block CU limits in response to actual network demand, ensuring Solana scale's with Moore's Law and exponentially increasing bandwidth. 
+The goal of this proposal is to enhance the scalability and efficiency of the
+Solana network by dynamically adjusting block CU limits in response to actual
+network demand, ensuring Solana scale's with Moore's Law and exponentially
+increasing bandwidth.
 
 ## Alternatives Considered
 
-**Manual Adjustment**: Periodic manual reviews of network performance to adjust CU limits. This lacks responsiveness, flexibility, and may be an arbitrary or centralized decision.
-
-**Pros**:
-- Offers real-time adjustment according to what the network has demonstrated it can handle.
-- Directly targets network demand and capacity issues.
-
-**Cons**:
-- If there is a very large spike or step function increase in demand, it may take several epochs to adjust.
+**Manual Adjustment**: Periodic manual reviews of network performance to adjust
+CU limits. This lacks responsiveness, flexibility, and may be an arbitrary or
+centralized decision.
 
 ## New Terminology
 
 - **Dynamic Block Limit**: Adjusting block CU limits based on network demand.
-- **Epoch Average Utilization**: The average utilization of CU within blocks over an epoch.
+- **Epoch Average Utilization**: The average CU utilization over an epoch.
 - **CU Limit Adjustment**: The process of modifying the block's CU limit.
 
 ## Detailed Design
 
 ### Implementation
 
-- **Epoch Utilization Calculation**: Record each block's CU utilization to calculate the average for the epoch.
-- **Adjustment Criteria**: Increase CU limit by 20% if average utilization >75%, decrease by 20% if <25%.
-- **Safety Measures**: Implement maximum and minimum CU limits to prevent extreme adjustments.
+Record each block's CU utilization to calculate the average for the epoch.
+Increase CU limit by 20% if average utilization >75%, decrease by 20% if <25%.
+
+**Safety Measures**: Implement maximum and minimum CU limits to prevent extreme adjustments.
 
 ### Interaction and Integration
 
-- Fits into the Solana runtime as a dynamic parameter adjustment mechanism. (Perhaps in the future, other constant parameters can be made dynamic using a similar mechanism.)
-- Will require updates to how block capacity is calculated and adjusted at the epoch level.
+- Fits into the Solana runtime as a dynamic parameter adjustment mechanism.
+(Perhaps in the future, other constant parameters can be made dynamic using a
+similar mechanism.)
+- Will require updates to how block capacity is calculated and adjusted at the
+epoch level.
 
 ## Impact
 
-- **Validators**: Will benefit from more consistent network performance and potentially higher throughput during peak times. Revenue capacity will increase naturally with better hardware, incentivizing validators to upgrade collectively.
-- **Core Contributors**: Need to consider implications on network stability and performance monitoring.
+**Validators**: Will benefit from more consistent network performance and
+potentially higher throughput during peak times. Revenue capacity will increase
+naturally with better hardware, incentivizing validators to upgrade collectively.
+
+**Core Contributors**: Need to consider implications on network stability and
+performance monitoring.
 
 ## Security Considerations
 
-Implementing dynamic block limits must not introduce vectors for DoS attacks or manipulation of block capacity. Thorough testing, simulations, and historical analyses are required to ensure the mechanism's resilience against such threats.
+Implementing dynamic block limits must not introduce vectors for DoS attacks or
+manipulation of block capacity. Thorough testing, simulations, and historical
+analyses are required to ensure the mechanism's resilience against such threats.
 
 ## Drawbacks
 
-- Complexity: Introducing dynamic block limits adds complexity to the network's operation and monitoring.
+**Pros**:
+
+- Offers real-time adjustment according to demonstrated network capacity.
+- Directly targets network demand and capacity issues.
+
+**Cons**:
+
+- It may take several epochs to adjust to a large step function increase in demand.
+- Introducing dynamic block limits adds complexity to the network's operation/monitoring.
 
 ## Backwards Compatibility
 

--- a/proposals/0130-dynamic-block-limits.md
+++ b/proposals/0130-dynamic-block-limits.md
@@ -68,7 +68,7 @@ serves as a stake-weighted metric of block utilization. This is a indicator of
 true current demand and capacity; the EAU can only be observed to be above the
 threshold if the network demonstrates that it can handle such compute and that there
 is demand for it. **It is important to not increase CU limits if there is no demand
-for it, as arbitrarily increasing utilization  opens up a vector for validators
+for it, as arbitrarily increasing the CU limit opens up a vector for validators
 to produce fat blocks that the rest of the network may struggle to replay.**
 
 The second metric is present to preserve protocol liveness and responsive UX. If

--- a/proposals/0130-dynamic-block-limits.md
+++ b/proposals/0130-dynamic-block-limits.md
@@ -1,0 +1,73 @@
+---
+simd: '0130'
+title: Dynamic Block Limits
+authors:
+  - Cavey Cool, Magnetar Fields
+category: Standard
+type: Core
+status: Draft
+created: 2024-03-24
+feature: (fill in with feature tracking issues once accepted)
+supersedes: (optional - fill this in if the SIMD supersedes a previous SIMD)
+extends: (optional - fill this in if the SIMD extends the design of a previous
+ SIMD)
+---
+
+# SIMD Proposal: Dynamic Block Limits
+
+## Summary
+
+This proposal introduces dynamic adjustments to the compute unit (CU) limit of Solana blocks based on network utilization at the end of each epoch. If the average block utilization exceeds 75%, the CU limit will increase by 20%; if it falls below 25%, the limit will decrease by 20%. This mechanism aims to optimize network performance by adapting to actual demand without centralized or arbitrary adjustments.
+
+## Motivation
+
+The goal of this proposal is to enhance the scalability and efficiency of the Solana network by dynamically adjusting block CU limits in response to actual network demand, ensuring Solana scale's with Moore's Law and exponentially increasing bandwidth. 
+
+## Alternatives Considered
+
+**Manual Adjustment**: Periodic manual reviews of network performance to adjust CU limits. This lacks responsiveness, flexibility, and may be an arbitrary or centralized decision.
+
+**Pros**:
+- Offers real-time adjustment according to what the network has demonstrated it can handle.
+- Directly targets network demand and capacity issues.
+
+**Cons**:
+- If there is a very large spike or step function increase in demand, it may take several epochs to adjust.
+
+## New Terminology
+
+- **Dynamic Block Limit**: Adjusting block CU limits based on network demand.
+- **Epoch Average Utilization**: The average utilization of CU within blocks over an epoch.
+- **CU Limit Adjustment**: The process of modifying the block's CU limit.
+
+## Detailed Design
+
+### Implementation
+
+- **Epoch Utilization Calculation**: Record each block's CU utilization to calculate the average for the epoch.
+- **Adjustment Criteria**: Increase CU limit by 20% if average utilization >75%, decrease by 20% if <25%.
+- **Safety Measures**: Implement maximum and minimum CU limits to prevent extreme adjustments.
+
+### Interaction and Integration
+
+- Fits into the Solana runtime as a dynamic parameter adjustment mechanism. (Perhaps in the future, other constant parameters can be made dynamic using a similar mechanism.)
+- Will require updates to how block capacity is calculated and adjusted at the epoch level.
+
+## Impact
+
+- **Validators**: Will benefit from more consistent network performance and potentially higher throughput during peak times. Revenue capacity will increase naturally with better hardware, incentivizing validators to upgrade collectively.
+- **Core Contributors**: Need to consider implications on network stability and performance monitoring.
+
+## Security Considerations
+
+Implementing dynamic block limits must not introduce vectors for DoS attacks or manipulation of block capacity. Thorough testing, simulations, and historical analyses are required to ensure the mechanism's resilience against such threats.
+
+## Drawbacks
+
+- Complexity: Introducing dynamic block limits adds complexity to the network's operation and monitoring.
+- Predictability: Frequent changes in CU limits may affect the predictability of transaction processing times and fees.
+
+## Backwards Compatibility
+
+- The proposal requires network-wide coordination for activation.
+- No direct breaking changes, but dApps and transaction submission strategies may need adjustments.

--- a/proposals/0130-dynamic-block-limits.md
+++ b/proposals/0130-dynamic-block-limits.md
@@ -55,12 +55,13 @@ supermajority vote slot latency (SVSL).
 
 Increase CU limit by 20% if:
 
-1. EAU is greater than 75%.
-2. SVSL is below target vote slot latency (TBD).
+1. EAU is greater than 75%, **AND**
+2. SVSL is below threshold vote slot latency (TBD).
 
 Decrease CU limit by 20% if:
 
-1. EAU is less than 25%.
+1. EAU is less than 25%, **OR**
+2. SVSL is above threshold vote slot latency (TBD).
 
 It is worth discussing the reasoning for the two criteria for increasing the CU
 limit. Since the block schedule is determined by stake, the first metric (EAU)
@@ -70,6 +71,9 @@ threshold if the network demonstrates that it can handle such compute and that t
 is demand for it. **It is important to not increase CU limits if there is no demand
 for it, as arbitrarily increasing the CU limit opens up a vector for validators
 to produce fat blocks that the rest of the network may struggle to replay.**
+Thus, the increase criteria can be summarized as follows: increase capacity if
+there is demonstrated capacity and demand for it **AND** if it does not threaten
+protocol liveness or degrade UX.
 
 The second metric is present to preserve protocol liveness and responsive UX. If
 the SVSL is above the target threshold, it means that there are nodes in the
@@ -77,7 +81,9 @@ supermajority that are struggling to replay and vote within the target latency.
 This threatens protocol liveness, as it can be an indicator of nodes within the
 supermajority not being able to catch up to the tip. Furthermore, vote slot
 latency is directly tied to the solana user experience; it can serve as a proxy
-metric for finalization time.
+metric for finalization time. Thus, the decrease criteria can be summarized as
+follows: decrease capacity if there is no demonstrated demand for it **OR** if
+the current limits are threatening protocol liveness or degrading UX.
 
 By setting thresholds at 75% and 25%, this proposal very roughly targets a 50%
 block utilization. It is important to recognize that validator hardware is

--- a/proposals/0130-dynamic-block-limits.md
+++ b/proposals/0130-dynamic-block-limits.md
@@ -49,7 +49,7 @@ in an epoch.
 
 ### Implementation
 
-Record each block's CU utilization in an epoch and calcualate the epoch average
+Record each block's CU utilization in an epoch and calculate the epoch average
 utilization (EAU). Record the slot latency of votes in an epoch and calculate the
 supermajority vote slot latency (SVSL).
 
@@ -79,7 +79,7 @@ supermajority not being able to catch up to the tip. Furthermore, vote slot
 latency is directly tied to the solana user experience; it can serve as a proxy
 metric for finalization time.
 
-By setting thresholds at 75% and 25%, This proposal very roughly targets a 50%
+By setting thresholds at 75% and 25%, this proposal very roughly targets a 50%
 block utilization. It is important to recognize that validator hardware is
 inhomogeneous, and block producing capacity will vary from node to node. If the
 average utilization is too high, it means that the protocol is throttling nodes

--- a/proposals/0130-dynamic-block-limits.md
+++ b/proposals/0130-dynamic-block-limits.md
@@ -65,9 +65,7 @@ Implementing dynamic block limits must not introduce vectors for DoS attacks or 
 ## Drawbacks
 
 - Complexity: Introducing dynamic block limits adds complexity to the network's operation and monitoring.
-- Predictability: Frequent changes in CU limits may affect the predictability of transaction processing times and fees.
 
 ## Backwards Compatibility
 
 - The proposal requires network-wide coordination for activation.
-- No direct breaking changes, but dApps and transaction submission strategies may need adjustments.

--- a/proposals/0130-dynamic-block-limits.md
+++ b/proposals/0130-dynamic-block-limits.md
@@ -90,12 +90,12 @@ By setting thresholds at 75% and 25%, this proposal very roughly targets a 50%
 block utilization. It is important to recognize that validator hardware is
 inhomogeneous, and block producing capacity will vary from node to node. If the
 average utilization is too high, it means that the protocol is throttling nodes
-with high end hardware that could be producing more profitable blocks. If the average
-utilization is too low, then it means that the limits are either too high or there
-is no demonstrated demand for blockspace. By roughly targeting 50% utilization,
-and with the aforementioned checks in place, nodes with higher end hardware are
-allowed to produce slightly larger blocks than other nodes without threatening
-protocol liveness.
+with high end hardware that could be producing more profitable blocks. If the
+average utilization is too low, then it means that the limits are either too
+high or there is no demonstrated demand for blockspace. By roughly targeting 50%
+utilization, and with the aforementioned checks in place, nodes with higher end
+hardware are allowed to produce slightly larger blocks than other nodes without
+threatening protocol liveness.
 
 **Safety Measures**: Implement maximum and minimum CU limits to prevent extreme adjustments.
 

--- a/proposals/0130-dynamic-block-limits.md
+++ b/proposals/0130-dynamic-block-limits.md
@@ -62,7 +62,7 @@ Decrease CU limit by 20% if:
 
 1. EAU is less than 25%.
 
-It is worth discussing the reasoning for the two critera for increasing the CU
+It is worth discussing the reasoning for the two criteria for increasing the CU
 limit. Since the block schedule is determined by stake, the first metric (EAU)
 serves as a stake-weighted metric of block utilization. This is a indicator of
 true current demand and capacity; the EAU can only be observed to be above the
@@ -71,9 +71,9 @@ is demand for it. **It is important to not increase CU limits if there is no dem
 for it, as arbitrarily increasing utilization  opens up a vector for validators
 to produce fat blocks that the rest of the network may struggle to replay.**
 
-The second metric is present to preserve protocol liveness liveness and responsive
-UX. If the SVSL is above the target threshold, it means that there are nodes in
-the supermajority that are struggling to replay and vote within the target latency.
+The second metric is present to preserve protocol liveness and responsive UX. If
+the SVSL is above the target threshold, it means that there are nodes in the
+supermajority that are struggling to replay and vote within the target latency.
 This threatens protocol liveness, as it can be an indicator of nodes within the
 supermajority not being able to catch up to the tip. Furthermore, vote slot
 latency is directly tied to the solana user experience; it can serve as a proxy

--- a/proposals/0130-dynamic-block-limits.md
+++ b/proposals/0130-dynamic-block-limits.md
@@ -28,7 +28,7 @@ without voting.
 
 The goal of this proposal is to enhance the scalability and efficiency of the
 Solana network by dynamically adjusting block CU limits in response to actual
-network demand, ensuring Solana scale's with Moore's Law and exponentially
+network demand, ensuring Solana scales with Moore's Law and exponentially
 increasing bandwidth.
 
 ## Alternatives Considered


### PR DESCRIPTION
# SIMD Proposal: Dynamic Block Limits

## Summary

This proposal introduces dynamic adjustments to the compute unit (CU) limit of Solana blocks based on network utilization at the end of each epoch. If the average block utilization exceeds 75%, the CU limit will increase by 20%; if it falls below 25%, the limit will decrease by 20%. A second metric based on vote slot latency is used to preserve protocol liveness and responsive UX. This proposal aims to optimize network performance by adapting to demonstrated compute capacity and demand without centralized decisions about limits and without voting.Although the adjustment rate is arbitrary (and can be discussed in this PR), the block limit will be determined by the demonstrated capacity of the network without voting.