### PR TITLE
Amend SIMD0127 to remove SlotHistory

### DIFF
--- a/proposals/0127-get-sysvar-syscall.md
+++ b/proposals/0127-get-sysvar-syscall.md
@@ -196,7 +196,6 @@ The supported list of sysvars for the proposed syscall will be as follows:
 - `SysvarLastRestartS1ot1111111111111111111111`
 - `SysvarRent111111111111111111111111111111111`
 - `SysvarS1otHashes111111111111111111111111111`
-- `SysvarS1otHistory11111111111111111111111111`
 - `SysvarStakeHistory1111111111111111111111111`
 
 Sysvar APIs at the SDK level are responsible for defining exactly how the data


### PR DESCRIPTION
the purpose of simd0127 is to provide convenient access to sysvar data for programs, particularly native programs being ported to bpf which currently get this information via their `InvokeContext` and cannot have breaking changes made to their instructions to require accounts be passed in that presently are not

`SlotHistory` is used in no programs and isnt part of the existing sysvar cache provided by the invoke context. it has no reasonable utility and shouldnt be part of the simd

cc @buffalojoec @ripatel-fd for approval and @jacobcreech for process oversight