### PR TITLE
SIMD-0118: Update StakeError definition

### DIFF
--- a/proposals/0118-partitioned-epoch-reward-distribution.md
+++ b/proposals/0118-partitioned-epoch-reward-distribution.md
@@ -226,7 +226,7 @@ new error code:
 
 ```
 StakeError {
-   EpochRewardsDistributionActive = 15,
+   EpochRewardsActive = 16,
 }
 ```
 


### PR DESCRIPTION
SIMD-0118 specifies a StakeError variant index that is already taken; this is just a typo due to miscounting (author may need a preschool refresher). This PR fixes the index.
This PR also updates the variant text to match the Agave implementation; this is not important to the spec, so I will revert if desired. But the updated text is more accurate, since the error will also be thrown during the calculation block.