### PR TITLE
Amend 0133: Support total cluster stake

### DIFF
--- a/proposals/0133-syscall-get-epoch-stake.md
+++ b/proposals/0133-syscall-get-epoch-stake.md
@@ -102,7 +102,7 @@ syscall_base + floor(PUBKEY_BYTES/cpi_bytes_per_unit) + mem_op_base
 If `var_addr` is a null pointer:
 
 ```
-syscall_base + mem_op_base
+syscall_base
 ```
 
 - `PUBKEY_BYTES`: 32 bytes for an Ed25519 public key.

--- a/proposals/0133-syscall-get-epoch-stake.md
+++ b/proposals/0133-syscall-get-epoch-stake.md
@@ -78,20 +78,27 @@ uint64_t sol_get_epoch_stake(/* r1 */ void const * vote_addr);
 
 If `var_addr` is _not_ a null pointer:
 
-- The syscall aborts the virtual machine if not all bytes in VM memory range
-  `[vote_addr, vote_addr + 32)` are readable.
+- The syscall aborts the virtual machine if:
+    - Not all bytes in VM memory range `[vote_addr, vote_addr + 32)` are
+      readable.
+    - Compute budget is exceeded.
 - Otherwise, the syscall returns a `u64` integer representing the total active
   stake delegated to the vote account at the provided address.
   If the provided vote address corresponds to an account that is not a vote
   account or does not exist, the syscall will return `0` for active stake.
 
-If `var_addr` is a null pointer, the syscall returns a `u64` integer
-representing the total active stake on the cluster for the current epoch.
+If `var_addr` is a null pointer:
+
+- The syscall aborts the virtual machine if:
+    - Compute budget is exceeded.
+- Otherwise, the syscall returns a `u64` integer representing the total active
+  stake on the cluster for the current epoch.
 
 ### Compute Unit Usage
 
-The syscall will always attempt to consume the same amount of CUs for both
-possible `var_addr` pointers, regardless of control flow.
+The syscall will always consume a fixed amount of CUs regardless of control
+flow. This fixed amount can be one of two values, depending on whether a null
+pointer was provided for `var_addr`.
 
 If `var_addr` is _not_ a null pointer:
 


### PR DESCRIPTION
Amend SIMD 0133 - Syscall `GetEpochStake` - to support retrieval of the
_total cluster stake_, in addition to a vote account's stake, for the current
epoch.

The main change here is that a null pointer will allow callers to retrieve the
total cluster stake for the epoch.

A potential point of contention is going to be the designated compute usage
for retrieval of total stake.

cc @michaelh-laine