### PR TITLE
Update SIMD-0001

### DIFF
--- a/.github/linter/customRules.ts
+++ b/.github/linter/customRules.ts
@@ -287,6 +287,7 @@ export const metadataStatusIsValid = {
       "Stagnant",
       "Withdrawn",
       "Implemented",
+      "Activated",
     ]
 
     if (!validStatus.includes(status)) {

--- a/.github/linter/customRules.ts
+++ b/.github/linter/customRules.ts
@@ -281,6 +281,7 @@ export const metadataStatusIsValid = {
 
     const validStatus = [
       "Idea",
+      "Draft", 
       "Review",
       "Accepted",
       "Stagnant",

--- a/.github/linter/customRules.ts
+++ b/.github/linter/customRules.ts
@@ -281,7 +281,6 @@ export const metadataStatusIsValid = {
 
     const validStatus = [
       "Idea",
-      "Draft",
       "Review",
       "Accepted",
       "Stagnant",

--- a/README.md
+++ b/README.md
@@ -3,33 +3,33 @@
 The goal of the SIMD project is to standardize and provide high-quality
 documentation for Solana and its ecosystem. This repository tracks past and
 ongoing improvements to Solana in the form of Solana Improvement Documents
-(SIMDs). 
-[SIMD-0001](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0001-simd-process.md) 
+(SIMDs).
+[SIMD-0001](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0001-simd-process.md)
 governs the SIMD process.
 
 ## SIMD Types
 
 SIMDs can be divided into the following categories:
 
-- **Standard SIMDs**: 
-Describe changes that affect most or all Solana implementations, such as:
-  - **Core**: 
-  Changes affecting consensus or substantial changes to the validator.
-  - **Networking**: 
-  Changes or substantial improvements to network protocol specifications.
-  - **Interfaces**: 
-  Breaking changes around the client JSON RPC API specifications and standards.
-- **Meta SIMDs**: 
-Describe a process surrounding Solana or propose a change to (or an event in) 
-a process.
+- **Standard SIMDs**:
+  Describe changes that affect most or all Solana implementations, such as:
+  - **Core**:
+    Changes affecting consensus or substantial changes to the validator.
+  - **Networking**:
+    Changes or substantial improvements to network protocol specifications.
+  - **Interfaces**:
+    Breaking changes around the client JSON RPC API specifications and standards.
+- **Meta SIMDs**:
+  Describe a process surrounding Solana or propose a change to (or an event in)
+  a process.
 
 ## Before You Begin
 
-Before you write a SIMD, ideas MUST be thoroughly discussed and vetted on the 
-[ideas section](https://github.com/solana-foundation/solana-improvement-documents/discussions/categories/ideas) 
-within this 
-[repo's disucssion page](https://github.com/solana-foundation/solana-improvement-documents/discussions). 
-Read and review [SIMD-0001](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0001-simd-process.md), 
+Before you write a SIMD, ideas MUST be thoroughly discussed and vetted on the
+[ideas section](https://github.com/solana-foundation/solana-improvement-documents/discussions/categories/ideas)
+within this
+[repo's disucssion page](https://github.com/solana-foundation/solana-improvement-documents/discussions).
+Read and review [SIMD-0001](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0001-simd-process.md),
 which describes the SIMD process in detail.
 
 This repository is for documenting standards and not for implementation help.
@@ -39,7 +39,7 @@ of this [repo's disucssion page](https://github.com/solana-foundation/solana-imp
 
 ## Access Policy
 
-The SIMD repository has three levels of access, as detailed in 
+The SIMD repository has three levels of access, as detailed in
 [SIMD-0007](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0007-access-policy.md):
 
 1. Triage
@@ -48,4 +48,3 @@ The SIMD repository has three levels of access, as detailed in
 
 To request access or report misuse, please follow the procedures outlined in
 SIMD-0007.
-

--- a/README.md
+++ b/README.md
@@ -1,2 +1,30 @@
-# Solana Improvement Documents
-Solana IMprovement Documents (SIMD) describe proposed and accepted changes to the Solana protocol.
+# Solana Improvement Documents (SIMDs)
+
+The goal of the SIMD project is to standardize and provide high-quality documentation for Solana and its ecosystem. This repository tracks past and ongoing improvements to Solana in the form of Solana Improvement Documents (SIMDs). [SIMD-0001](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0001-simd-process.md) governs the SIMD process.
+
+## SIMD Types
+
+SIMDs can be divided into the following categories:
+
+- **Standard SIMDs**: Describe changes that affect most or all Solana implementations, such as:
+  - **Core**: Changes affecting consensus or substantial changes to the validator.
+  - **Networking**: Changes or substantial improvements to network protocol specifications.
+  - **Interfaces**: Breaking changes around the client JSON RPC API specifications and standards.
+- **Meta SIMDs**: Describe a process surrounding Solana or propose a change to (or an event in) a process.
+
+## Before You Begin
+
+Before you write a SIMD, ideas MUST be thoroughly discussed and vetted on the [ideas section](https://github.com/solana-foundation/solana-improvement-documents/discussions/categories/ideas) within this [repo's disucssion page](https://github.com/solana-foundation/solana-improvement-documents/discussions). Read and review [SIMD-0001](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0001-simd-process.md), which describes the SIMD process in detail.
+
+This repository is for documenting standards and not for implementation help. For specific questions and concerns regarding SIMDs, it's best to discuss them in the [questions section](https://github.com/solana-foundation/solana-improvement-documents/discussions/categories/questions) of this [repo's disucssion page](https://github.com/solana-foundation/solana-improvement-documents/discussions).
+
+## Access Policy
+
+The SIMD repository has three levels of access, as detailed in [SIMD-0007](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0007-access-policy.md):
+
+1. Triage
+2. Write
+3. Maintain
+
+To request access or report misuse, please follow the procedures outlined in SIMD-0007.
+

--- a/README.md
+++ b/README.md
@@ -1,30 +1,51 @@
 # Solana Improvement Documents (SIMDs)
 
-The goal of the SIMD project is to standardize and provide high-quality documentation for Solana and its ecosystem. This repository tracks past and ongoing improvements to Solana in the form of Solana Improvement Documents (SIMDs). [SIMD-0001](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0001-simd-process.md) governs the SIMD process.
+The goal of the SIMD project is to standardize and provide high-quality
+documentation for Solana and its ecosystem. This repository tracks past and
+ongoing improvements to Solana in the form of Solana Improvement Documents
+(SIMDs). 
+[SIMD-0001](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0001-simd-process.md) 
+governs the SIMD process.
 
 ## SIMD Types
 
 SIMDs can be divided into the following categories:
 
-- **Standard SIMDs**: Describe changes that affect most or all Solana implementations, such as:
-  - **Core**: Changes affecting consensus or substantial changes to the validator.
-  - **Networking**: Changes or substantial improvements to network protocol specifications.
-  - **Interfaces**: Breaking changes around the client JSON RPC API specifications and standards.
-- **Meta SIMDs**: Describe a process surrounding Solana or propose a change to (or an event in) a process.
+- **Standard SIMDs**: 
+Describe changes that affect most or all Solana implementations, such as:
+  - **Core**: 
+  Changes affecting consensus or substantial changes to the validator.
+  - **Networking**: 
+  Changes or substantial improvements to network protocol specifications.
+  - **Interfaces**: 
+  Breaking changes around the client JSON RPC API specifications and standards.
+- **Meta SIMDs**: 
+Describe a process surrounding Solana or propose a change to (or an event in) 
+a process.
 
 ## Before You Begin
 
-Before you write a SIMD, ideas MUST be thoroughly discussed and vetted on the [ideas section](https://github.com/solana-foundation/solana-improvement-documents/discussions/categories/ideas) within this [repo's disucssion page](https://github.com/solana-foundation/solana-improvement-documents/discussions). Read and review [SIMD-0001](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0001-simd-process.md), which describes the SIMD process in detail.
+Before you write a SIMD, ideas MUST be thoroughly discussed and vetted on the 
+[ideas section](https://github.com/solana-foundation/solana-improvement-documents/discussions/categories/ideas) 
+within this 
+[repo's disucssion page](https://github.com/solana-foundation/solana-improvement-documents/discussions). 
+Read and review [SIMD-0001](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0001-simd-process.md), 
+which describes the SIMD process in detail.
 
-This repository is for documenting standards and not for implementation help. For specific questions and concerns regarding SIMDs, it's best to discuss them in the [questions section](https://github.com/solana-foundation/solana-improvement-documents/discussions/categories/questions) of this [repo's disucssion page](https://github.com/solana-foundation/solana-improvement-documents/discussions).
+This repository is for documenting standards and not for implementation help.
+For specific questions and concerns regarding SIMDs, it's best to discuss them
+in the [questions section](https://github.com/solana-foundation/solana-improvement-documents/discussions/categories/questions)
+of this [repo's disucssion page](https://github.com/solana-foundation/solana-improvement-documents/discussions).
 
 ## Access Policy
 
-The SIMD repository has three levels of access, as detailed in [SIMD-0007](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0007-access-policy.md):
+The SIMD repository has three levels of access, as detailed in 
+[SIMD-0007](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0007-access-policy.md):
 
 1. Triage
 2. Write
 3. Maintain
 
-To request access or report misuse, please follow the procedures outlined in SIMD-0007.
+To request access or report misuse, please follow the procedures outlined in
+SIMD-0007.
 

--- a/proposals/0001-simd-process.md
+++ b/proposals/0001-simd-process.md
@@ -3,6 +3,7 @@ simd: '0001'
 title: Solana Proposal Process
 authors:
   - Jacob Creech (Solana Foundation)
+  - Ben Hawkins (Solana Foundation)
 category: Meta
 type: Meta
 status: Living
@@ -83,6 +84,7 @@ The stages in a lifecycle of a proposal are as follows:
 - Stagnant
 - Withdrawn
 - Implemented
+- Activated
 
 ```mermaid
 flowchart LR
@@ -116,9 +118,7 @@ proposal author -- the reviewers, and the Solana Core Contributors.
 
 Before you begin writing a formal proposal, you should vet your idea. Ask the
 Solana core community first if an idea is original to avoid wasting time on
-something that will be rejected based on prior research. It is thus recommended
-to discuss the proposal on the Solana Tech Discord under the #core-technology
-channel.
+something that will be rejected based on prior research. Be sure to post your ideas to the [SIMD ideas discussion page](https://github.com/solana-foundation/solana-improvement-documents/discussions/categories/ideas) and gather feedback before making your formal Proposal
 
 ### Draft
 
@@ -130,7 +130,7 @@ is descriptive)
 - Fill in the proposal. Put care into the details: proposals that do not
 present convincing motivation, demonstrate lack of understanding of the
 design's impact, or are disingenuous about the drawbacks or alternatives tend
-to be poorly received.
+to be poorly received. Low quality proposals with limited engagement will be closed regularly.
 - Submit a pull request.
 - Now that your proposal has an open pull request, use the issue number of the
 PR to update the `XXXX-` prefix to the number.
@@ -159,6 +159,11 @@ issue for tracking across clusters should also be created. While it is not
 far the most effective way to see a proposal through to completion: authors
 should not expect that other project developers will take on responsibility for
 implementing their accepted feature.
+
+### Activated
+
+Once a proposal has been implemented, tested, and finally activated on mainnet it's
+status 
 
 ### Living
 

--- a/proposals/0001-simd-process.md
+++ b/proposals/0001-simd-process.md
@@ -169,12 +169,12 @@ implementing their accepted feature.
 
 ### Implemented
 
-When all relevant teams have completed development of the feature the SIMD's is "Implemented"
+When all relevant teams have completed development of the SIMD's feature, the SIMD is "Implemented".
 
 ### Activated
 
 A proposal will have the status Activated once it has been implemented,
-tested, and finally activated on mainnet. 
+tested, and finally activated on mainnet beta. 
 
 ### Living
 

--- a/proposals/0001-simd-process.md
+++ b/proposals/0001-simd-process.md
@@ -118,7 +118,10 @@ proposal author -- the reviewers, and the Solana Core Contributors.
 
 Before you begin writing a formal proposal, you should vet your idea. Ask the
 Solana core community first if an idea is original to avoid wasting time on
-something that will be rejected based on prior research. Be sure to post your ideas to the [SIMD ideas discussion page](https://github.com/solana-foundation/solana-improvement-documents/discussions/categories/ideas) and gather feedback before making your formal Proposal
+something that will be rejected based on prior research. Be sure to post your
+ideas to the 
+[SIMD ideas discussion page](https://github.com/solana-foundation/solana-improvement-documents/discussions/categories/ideas)
+and gather feedback before making your formal Proposal
 
 ### Draft
 
@@ -130,7 +133,8 @@ is descriptive)
 - Fill in the proposal. Put care into the details: proposals that do not
 present convincing motivation, demonstrate lack of understanding of the
 design's impact, or are disingenuous about the drawbacks or alternatives tend
-to be poorly received. Low quality proposals with limited engagement will be closed by SIMD repository maintainers.
+to be poorly received. Low quality proposals with limited engagement will be 
+closed by SIMD repository maintainers.
 - Submit a pull request.
 - Now that your proposal has an open pull request, use the issue number of the
 PR to update the `XXXX-` prefix to the number.
@@ -162,7 +166,8 @@ implementing their accepted feature.
 
 ### Activated
 
-A proposal will have the status Activated once it has been implemented, tested, and finally activated on mainnet. 
+A proposal will have the status Activated once it has been implemented,
+tested, and finally activated on mainnet. 
 
 ### Living
 

--- a/proposals/0001-simd-process.md
+++ b/proposals/0001-simd-process.md
@@ -169,7 +169,8 @@ implementing their accepted feature.
 
 ### Implemented
 
-When all relevant teams have completed development of the SIMD's feature, the SIMD is "Implemented".
+When all relevant teams have completed development of the SIMD's feature, the 
+SIMD is "Implemented".
 
 ### Activated
 

--- a/proposals/0001-simd-process.md
+++ b/proposals/0001-simd-process.md
@@ -104,8 +104,10 @@ flowchart LR
   Idea ---> Draft;
   Draft ---> Review;
   Review ---> Accepted;
-  Accepted ---> Implemented
+  Accepted ---> Implemented;
+  Implemented ---> Activated;
   Review ---> Living;
+  Accepted ---> Withdrawn;
 
   Draft ---> Stagnant;
   Review ---> Stagnant;
@@ -164,6 +166,9 @@ issue for tracking across clusters should also be created. While it is not
 far the most effective way to see a proposal through to completion: authors
 should not expect that other project developers will take on responsibility for
 implementing their accepted feature.
+
+### Implemented
+When all relevant teams have completed development of the feature the SIMD's is "Implemented"
 
 ### Activated
 

--- a/proposals/0001-simd-process.md
+++ b/proposals/0001-simd-process.md
@@ -130,7 +130,7 @@ is descriptive)
 - Fill in the proposal. Put care into the details: proposals that do not
 present convincing motivation, demonstrate lack of understanding of the
 design's impact, or are disingenuous about the drawbacks or alternatives tend
-to be poorly received. Low quality proposals with limited engagement will be closed regularly.
+to be poorly received. Low quality proposals with limited engagement will be closed by SIMD repository maintainers.
 - Submit a pull request.
 - Now that your proposal has an open pull request, use the issue number of the
 PR to update the `XXXX-` prefix to the number.
@@ -162,8 +162,7 @@ implementing their accepted feature.
 
 ### Activated
 
-Once a proposal has been implemented, tested, and finally activated on mainnet it's
-status 
+A proposal will have the status Activated once it has been implemented, tested, and finally activated on mainnet. 
 
 ### Living
 

--- a/proposals/0001-simd-process.md
+++ b/proposals/0001-simd-process.md
@@ -104,6 +104,7 @@ flowchart LR
   Idea ---> Draft;
   Draft ---> Review;
   Review ---> Accepted;
+  Accepted ---> Implemented
   Review ---> Living;
 
   Draft ---> Stagnant;

--- a/proposals/0001-simd-process.md
+++ b/proposals/0001-simd-process.md
@@ -168,6 +168,7 @@ should not expect that other project developers will take on responsibility for
 implementing their accepted feature.
 
 ### Implemented
+
 When all relevant teams have completed development of the feature the SIMD's is "Implemented"
 
 ### Activated


### PR DESCRIPTION
This update does 2 things:

1. Add a new status, Activated, that represents SIMDs that have been completed and activated on mainnet. 
2. Changes the direction to go to solana tech discord to discuss new SIMD ideas to use the newly added discussion pages on this repo [https://github.com/solana-foundation/solana-improvement-documents/discussions](https://github.com/solana-foundation/solana-improvement-documents/discussions)

If this PR gets accepted then I will post a PR updating all the existing SIMDs to their correct status and in the future we will only merge SIMDs with the status "Accepted". No more "Draft" status in the main canonical branch. 