### PR TITLE
template: move alternatives section below detailed design

### DIFF
--- a/XXXX-template.md
+++ b/XXXX-template.md
@@ -24,11 +24,6 @@ A brief summary of what the feature is.
 Why are we doing this? What use cases does it support? What is the expected
 outcome?
 
-## Alternatives Considered
-
-What alternative designs were considered and what pros/cons does this feature
-have relative to them?
-
 ## New Terminology
 
 Is there any new terminology introduced with this proposal?
@@ -49,6 +44,11 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 document are to be interpreted as described in [RFC
 2119](https://www.ietf.org/rfc/rfc2119.txt) and [RFC
 8174](https://www.ietf.org/rfc/rfc8174.txt).
+
+## Alternatives Considered
+
+What alternative designs were considered and what pros/cons does this feature
+have relative to them?
 
 ## Impact
 


### PR DESCRIPTION
#### Problem
The current template for SIMDs places the "Alternatives Considered" section before any details about the proposed design, including "Detailed Design" in particular.

This can be confusing for readers, since alternative designs usually reference the detailed design proposed in the "Detailed Design" section for contrast.

#### Summary of Changes
Move the "Alternatives Considered" section below "Detailed Design". With this setup, readers can consume the proposed design, then read the alternatives, after digesting the proposed design details. This should make the context much more clear when a reader reaches the "Alternatives Considered" section.