### PR TITLE
SIMD-118: update feature-gate info

### DIFF
--- a/proposals/0118-partitioned-epoch-reward-distribution.md
+++ b/proposals/0118-partitioned-epoch-reward-distribution.md
@@ -6,7 +6,7 @@ category: Standard
 type: Core
 status: Accepted
 created: 2024-02-16
-feature: 9bn2vTJUsUcnpiZWbu2woSKtTGW3ErZC9ERv88SDqQjK (https://github.com/anza-xyz/agave/issues/426)'
+feature: PERzQrt5gBD1XEe2c9XdFWqwgHY3mr7cYWbm5V772V8 (https://github.com/anza-xyz/agave/issues/426)
 supersedes: '0015'
 development:
    - Anza - Implemented (https://github.com/anza-xyz/agave/pull/427)


### PR DESCRIPTION
Testnet exposed a bug in the SIMD-118 implementation. That has been patched (to be released in Agave v2.0.9), and wrapped in a new superset feature gate. This PR updates the feature-gate details. The linked Agave feature issue retains the original feature ID.