### PR TITLE
SIMD-0208: Reopen Closed Programs

### DIFF
--- a/proposals/0208-reopen-closed-programs.md
+++ b/proposals/0208-reopen-closed-programs.md
@@ -6,7 +6,7 @@ authors:
   - justin.starry@icloud.com
 category: Standard
 type: Core
-status: Draft
+status: Review
 created: 2024-12-06
 feature:
 ---

--- a/proposals/0208-reopen-closed-programs.md
+++ b/proposals/0208-reopen-closed-programs.md
@@ -13,11 +13,18 @@ feature:
 
 ## Summary
 
-This proposal is the migration of the discussion found at https://github.com/solana-labs/solana/pull/27460, regarding closed program accounts not being recoverable. This SIMD proposes adding in the ability to reopen a closed program through the same mechanism as standard program deploys.
+This proposal is the migration of the discussion found at
+https://github.com/solana-labs/solana/pull/27460, regarding closed program
+accounts not being recoverable. This SIMD proposes adding in the ability to
+reopen a closed program through the same mechanism as standard program deploys.
 
 ## Motivation
 
-As it is the default behavior of all Solana accounts to be reopenable, the lack of this ability for program accounts seems like an oversight. More importantly, because it does not follow the default behavior, it would not be obvious to the average program deployer that closing a program is an irreversible operation that could permanently brick any accounts owned by the closed program.
+As it is the default behavior of all Solana accounts to be reopenable, the lack
+of this ability for program accounts seems like an oversight. More importantly,
+because it does not follow the default behavior, it would not be obvious to the
+average program deployer that closing a program is an irreversible operation
+that could permanently brick any accounts owned by the closed program.
 
 ## Alternatives Considered
 
@@ -31,4 +38,5 @@ As it is the default behavior of all Solana accounts to be reopenable, the lack 
 
 ## Security Considerations
 
-- Intentionally closed programs expecting the behavior that programs are incapable of being reopened.
+- Intentionally closed programs expecting the behavior that programs are
+  incapable of being reopened.

--- a/proposals/0208-reopen-closed-programs.md
+++ b/proposals/0208-reopen-closed-programs.md
@@ -1,5 +1,5 @@
 ---
-simd: "XXXX"
+simd: "0208"
 title: Allow Closed Programs to be Recreated
 authors:
   - keith@metaplex.foundation
@@ -13,9 +13,7 @@ feature:
 
 ## Summary
 
-This proposal is the migration of the discussion found at https://github.com/solana-labs/solana/pull/27460, regarding closed program accounts not being recoverable.
-
-This SIMD proposes adding in the ability to reopen a closed program through the same mechanism as standard program deploys.
+This proposal is the migration of the discussion found at https://github.com/solana-labs/solana/pull/27460, regarding closed program accounts not being recoverable. This SIMD proposes adding in the ability to reopen a closed program through the same mechanism as standard program deploys.
 
 ## Motivation
 

--- a/proposals/XXXX-reopen-closed-programs.md
+++ b/proposals/XXXX-reopen-closed-programs.md
@@ -1,0 +1,36 @@
+---
+simd: "XXXX"
+title: Allow Closed Programs to be Recreated
+authors:
+  - keith@metaplex.foundation
+  - justin.starry@icloud.com
+category: Standard
+type: Core
+status: Draft
+created: 2024-12-06
+feature:
+---
+
+## Summary
+
+This proposal is the migration of the discussion found at https://github.com/solana-labs/solana/pull/27460, regarding closed program accounts not being recoverable.
+
+This SIMD proposes adding in the ability to reopen a closed program through the same mechanism as standard program deploys.
+
+## Motivation
+
+As it is the default behavior of all Solana accounts to be reopenable, the lack of this ability for program accounts seems like an oversight. More importantly, because it does not follow the default behavior, it would not be obvious to the average program deployer that closing a program is an irreversible operation that could permanently brick any accounts owned by the closed program.
+
+## Alternatives Considered
+
+## New Terminology
+
+## Detailed Design
+
+## Impact
+
+- Previously closed programs could be reopened and accounts recovered.
+
+## Security Considerations
+
+- Intentionally closed programs expecting the behavior that programs are incapable of being reopened.


### PR DESCRIPTION
This proposal is the migration of the discussion found at https://github.com/solana-labs/solana/pull/27460, regarding closed program accounts not being recoverable. This SIMD proposes adding in the ability to reopen a closed program through the same mechanism as standard program deploys.