### PR TITLE
SIMD-0215: Adds Sam Kim to authors

### DIFF
--- a/proposals/0215-accounts-lattice-hash.md
+++ b/proposals/0215-accounts-lattice-hash.md
@@ -5,6 +5,7 @@ authors:
   - Brooks Prumo
   - Emanuele Cesena
   - Josh Siegel
+  - Sam Kim
 category: Standard
 type: Core
 status: Accepted


### PR DESCRIPTION
I was informed that @samkim-crypto was one of the original authors of the lattice hash SIMD, so adding him to the authors.