### PR TITLE
Fix header linter

### DIFF
--- a/.github/linter/customRules.ts
+++ b/.github/linter/customRules.ts
@@ -7,9 +7,9 @@ export const enforceHeaderStructure = {
   tags: ["structure"],
   function: function rule(params: RuleParams, onError: RuleOnError) {
     const string = params.frontMatterLines
-    .join("\n")
-    .trim()
-    .replace(/^-*$/gm, "")
+      .join("\n")
+      .trim()
+      .replace(/^-*$/gm, "")
 
     const frontMatter: any = yaml.load(string)
     if (!frontMatter) return
@@ -30,7 +30,7 @@ export const enforceHeaderStructure = {
 
     let tempHeadings = expectedHeadings;
 
-    while (index < expectedHeadings.length) {
+    while (index < filtered.length) {
       let token = filtered[index]
       tempHeadings = tempHeadings.filter(item => item !== token.line)
 


### PR DESCRIPTION
The header linter doesn't go through all the proposal headers when checking that the required headers are present. So if a proposal adds a custom header in the middle of the required headers, the linter will fail: https://github.com/solana-foundation/solana-improvement-documents/actions/runs/12943366763/job/36102577418