### PR TITLE
Rekeys SIMD-215

### DIFF
--- a/proposals/0215-accounts-lattice-hash.md
+++ b/proposals/0215-accounts-lattice-hash.md
@@ -10,9 +10,9 @@ category: Standard
 type: Core
 status: Accepted
 created: 2024-12-20
-feature: LtHaSHHsUge7EWTPVrmpuexKz6uVHZXZL6cgJa7W7Zn
+feature: LTHasHQX6661DaDD4S6A2TFi6QBuiwXKv66fB1obfHq
 development:
-  - Agave: Implemented (v2.2.0)
+  - Agave: Implemented (v2.2)
   - Firedancer: Implemented (v0.2)
 ---
 


### PR DESCRIPTION
The Agave code implementing SIMD-215 did not match the actual SIMD text, so we need to update the code. Since the feature gate is already in a release (v2.2), we need to rekey it.

Refer to https://github.com/anza-xyz/agave/pull/5336 for more information.