### PR TITLE
SIMD-0287: Message Headers with Compute Budget Metadata

### DIFF
--- a/proposals/SIMD-03
+++ b/proposals/SIMD-03
@@ -1,0 +1,79 @@
+---
+simd: 0287
+title: Message Headers with Compute Budget Metadata
+authors:
+  - Cavey Cool
+category: Standard
+type: Interface
+status: Idea/Review
+created: 2025-05-20
+feature: N/A
+---
+
+## Summary
+
+We introduce three new (candidate) versions for transaction format aiming at
+reducing the transaction footprint for compute budget instructions.
+
+## Motivation
+
+The use of compute budget instructions has become ubiquitous. These instructions
+currently have a nontrivial serialized footprint and are presently wasteful in
+their implementation. The information in these instructions can be compacted
+significantly, enabling users to fit a bit more data in their transaction payload.
+
+## Detailed Design
+
+### v1: Fixed Fields for Compute Unit Limit & Price
+
+- **Change**: `MessageHeader` is extended to include two new fields:
+  - `compute_unit_price` (u64)
+  - `compute_unit_limit` (u32)
+- **Serialization**: These fields are serialized immediately before the existing
+  three `u8` signature counters.
+
+### v2: Fixed Fields for Compute Unit Limit & Price, Loaded Data & Heap Requests
+
+- **Change**: `MessageHeader` is extended to include four new fields:
+  - `compute_unit_price` (u64)
+  - `compute_unit_limit` (u32)
+  - `loaded_accounts_data_limit` (u32)
+  - `requested_heap_bytes` (u32)
+- **Serialization**: These fields are serialized immediately before the existing
+  three `u8` signature counters.
+
+### v3: Dynamic Header
+
+- **Change**: Introduce a new `ComputeBudgetHeader` struct at the front of the
+    message, containing:
+  - `flags: u8` bitmask indicating which compute budget fields are present.
+  - Optional fields (`Option<u32>` or `Option<u64>`) for the parameters
+- **Serialization**:
+  1. Emit `flags` byte.
+  2. For each bit set in `flags`, serialize the corresponding field in order
+  without additional tags.
+  3. Follow with the existing `MessageHeader` (three `u8` counters) and the
+    rest of the message.
+
+## Alternatives Considered
+
+I am proposing all options considered.
+
+## Impact
+
+- **DApp Developers**: Clients can still submit legacy/v0, but can opt in to the
+  new format to save some bytes.
+- **Core Contributors**: Banking/Runtime must support parsing new versions.
+
+## Security Considerations
+
+- validators **MUST** reject messages with unknown budget `flags` bits (v3).
+
+## Drawbacks
+
+- Slight complexity in serializer/deserializer logic, particularly for v3.
+
+## Backwards Compatibility
+
+- `VersionedTransaction` has space in the variant discriminant to support these
+  versioned messsages.


### PR DESCRIPTION
## Summary

We introduce three new (candidate) versions for transaction format aiming at
reducing the transaction footprint for compute budget instructions.

## Motivation

The use of compute budget instructions has become ubiquitous. These instructions
currently have a nontrivial serialized footprint and are presently wasteful in
their implementation. The information in these instructions can be compacted
significantly, enabling users to fit a bit more data in their transaction payload.

## Detailed Design

### v1: Fixed Fields for Compute Unit Limit & Price

- **Change**: `MessageHeader` is extended to include two new fields:
  - `compute_unit_price` (u64)
  - `compute_unit_limit` (u32)
- **Serialization**: These fields are serialized immediately before the existing
  three `u8` signature counters.

### v2: Fixed Fields for Compute Unit Limit & Price, Loaded Data & Heap Requests

- **Change**: `MessageHeader` is extended to include four new fields:
  - `compute_unit_price` (u64)
  - `compute_unit_limit` (u32)
  - `loaded_accounts_data_limit` (u32)
  - `requested_heap_bytes` (u32)
- **Serialization**: These fields are serialized immediately before the existing
  three `u8` signature counters.

### v3: Dynamic Header

- **Change**: Introduce a new `ComputeBudgetHeader` struct at the front of the
    message, containing:
  - `flags: u8` bitmask indicating which compute budget fields are present.
  - Optional fields (`Option<u32>` or `Option<u64>`) for the parameters
- **Serialization**:
  1. Emit `flags` byte.
  2. For each bit set in `flags`, serialize the corresponding field in order
  without additional tags.
  3. Follow with the existing `MessageHeader` (three `u8` counters) and the
    rest of the message.
    
    
 # Example
We consider v0 (existing), v1, v2, v3 message with noop (no instructions), cu limit + price, and all four existing compute budget instructions. These are the serialized footprints.

```
v0 noop                    = 70
v0 with cu limit + price   = 122
v0 with full cb ix set     = 138

v1 noop                    = 82
v1 with cu limit + price   = 82
v1 with full cb ix set     = 130

v2 noop                    = 90
v2 with cu limit + price   = 90
v2 with full cb ix set     = 90

v3 noop                    = 71
v3 with cu limit + price   = 83
v3 with full cb ix set     = 91
```

The code for this can be found [here](https://github.com/cavemanloverboy/versioned-tx-simd/)