### PR TITLE
Amend simd-0123

### DIFF
--- a/proposals/0123-block-revenue-distribution.md
+++ b/proposals/0123-block-revenue-distribution.md
@@ -151,9 +151,7 @@ block of an epoch `N` and any time the node is restarted during the partitioned
 rewards distribution period.
 
 For each vote account, get its total active stake delegation
-during the reward epoch `N - 1`. Let this value be `A`. If `A` is zero, skip
-this vote account (any pending delegator rewards will be distributed in a future
-epoch when the vote account has active stake.)
+during the reward epoch `N - 1`. Let this value be `A`.
 
 Then for each vote account, get its pending delegator rewards from the
 `pending_delegator_rewards` field in the vote state at the end of reward epoch
@@ -161,10 +159,12 @@ Then for each vote account, get its pending delegator rewards from the
 is nothing to be distributed.
 
 Lastly, if this is the first block of epoch `N`, the vote state's
-`pending_delegator_rewards` field MUST be reset to `0` and `P` lamports MUST be
-deducted from the vote account's lamport balance and credited to the epoch
-rewards sysvar account's lamport balance before any transactions or votes are
-processed.
+`pending_delegator_rewards` field MUST be reset to `0`. Then, if `A` (active
+stake) is zero, the delegator rewards will effectively returned to the voter
+after the `pending_delegator_rewards` field is reset to `0`. Otherwise, if `A`
+is non-zero, `P` lamports MUST be debited from the vote account's lamport
+balance and credited to the epoch rewards sysvar account's lamport balance
+before any transactions or votes are processed.
 
 Note that unlike inflation rewards distribution, block revenue distribution will
 not impact any internal epoch rewards sysvar state fields like `total_rewards`

--- a/proposals/0123-block-revenue-distribution.md
+++ b/proposals/0123-block-revenue-distribution.md
@@ -146,9 +146,10 @@ distribution mechanism described in [SIMD-0118].
 
 #### Delegator Rewards Calculation
 
-Delegator rewards MUST be calculated during both the beginning of the first
-block of an epoch `N` and any time the node is restarted during the partitioned
-rewards distribution period.
+Delegator rewards MUST be calculated during the beginning of the first block of
+an epoch `N` where the first block is any block with a parent in the previous
+epoch. Rewards MUST be recalculated if a node is restarted during the partitioned
+rewards distribution period as described in [SIMD-0118].
 
 For each vote account, get its total active stake delegation
 during the reward epoch `N - 1`. Let this value be `A`.
@@ -181,10 +182,11 @@ reward distribution amount, truncating any sub-lamport portion.
 #### Delegator Rewards Distribution
 
 The reward distribution amounts for each stake account can then be used to
-construct a list of stake reward entries which MUST be partitioned and
-distributed according to [SIMD-0118].
+construct a list of stake reward entries which MUST be partitioned according to
+[SIMD-0118] which describes which stake rewards are distributed in each block
+during the partitioned rewards distribution period.
 
-During partitioned reward distribution in a given slot, when reward entries are
+During partitioned reward distribution for a given slot, when reward entries are
 used to distribute block revenue rewards, the epoch rewards sysvar account's
 lamport balance MUST be debited by the block revenue reward distribution amount
 to keep capitalization consistent.

--- a/proposals/0123-block-revenue-distribution.md
+++ b/proposals/0123-block-revenue-distribution.md
@@ -147,8 +147,8 @@ distribution mechanism described in [SIMD-0118].
 #### Delegator Rewards Calculation
 
 Delegator rewards MUST be calculated during both the beginning of the first
-block of an epoch `N` and after restarting during partitioned rewards
-distribution.
+block of an epoch `N` and any time the node is restarted during the partitioned
+rewards distribution period.
 
 For each vote account, get its total active stake delegation
 during the reward epoch `N - 1`. Let this value be `A`. If `A` is zero, skip
@@ -163,7 +163,8 @@ is nothing to be distributed.
 Lastly, if this is the first block of epoch `N`, the vote state's
 `pending_delegator_rewards` field MUST be reset to `0` and `P` lamports MUST be
 deducted from the vote account's lamport balance and credited to the epoch
-rewards sysvar account's lamport balance.
+rewards sysvar account's lamport balance before any transactions or votes are
+processed.
 
 Note that unlike inflation rewards distribution, block revenue distribution will
 not impact any internal epoch rewards sysvar state fields like `total_rewards`
@@ -175,7 +176,7 @@ epoch rewards sysvar lamport balance.
 For each individual stake account with an active non-zero delegation, multiply
 its active stake in reward epoch `N - 1` by `P`, and divide the result by
 `A` using integer division to get the individual stake account's block revenue
-reward distribution amount.
+reward distribution amount, truncating any sub-lamport portion.
 
 #### Delegator Rewards Distribution
 


### PR DESCRIPTION
> In the case of additional rewards, we move amounts from the vote account to the stake accounts. By the way, this will lead to writing all vote accounts every block (assuming the partition reward distribution is uniformly distributed), right?

> I think it’s better to follow the approach of SIMD-0118, but we’ll have to use a sysvar for that (since capitalization is not increased). That is, in the first block of the epoch, record the reward distribution amounts by vote accounts into the sysvar data, and move that amount to the sysvar.

_Originally posted by @dimandotsol in https://github.com/solana-foundation/solana-improvement-documents/pull/123#discussion_r2125735097_
            