### PR TITLE
SIMD-0337: Markers for Alpenglow Fast Leader Handover

### DIFF
--- a/proposals/0337-parent-ready-update-marker.md
+++ b/proposals/0337-parent-ready-update-marker.md
@@ -21,6 +21,9 @@ signals that the intended parent is different from what was initially indicated,
 paving the way for Fast Leader Handover support in Alpenglow (section 2.7 of
 https://www.anza.xyz/alpenglow-1-1).
 
+Fast Leader Handover will minimize the synchronization delay between consecutive
+leaders, increasing throughput.
+
 ## Motivation
 
 SIMD-0326 proposes Alpenglow, a consensus protocol specified in


### PR DESCRIPTION
We propose augmenting `BlockMarkerV1`, introduced in SIMD-0307, to include `BlockHeader` and `UpdateParent` variants. `BlockHeader`, placed at the beginning of a block, indicates the parent of the block. `UpdateParent` signals that the intended parent is different from what was initially indicated, paving the way for Fast Leader Handover support in Alpenglow (section 2.7 of https://www.anza.xyz/alpenglow-1-1).

Fast Leader Handover will minimize the synchronization delay between consecutive leaders, increasing throughput.

This SIMD purely introduces the types required for Fast Leader Handover - the algorithmic details of Fast Leader Handover itself are outlined in [SIMD-0326](https://github.com/solana-foundation/solana-improvement-documents/pull/326).

NOTE: Fast Leader Handover may also be referred to as "optimistic block production."