### PR TITLE
SIMD-0339: Increase CPI Account Info Limit

### DIFF
--- a/proposals/0339-increase-cpi-account-info-limit.md
+++ b/proposals/0339-increase-cpi-account-info-limit.md
@@ -1,6 +1,6 @@
 ---
 simd: '0339'
-title: Increase CPI Account Info Limit
+title: Increase CPI Account Infos Limit
 authors:
   - Justin Starry (Anza)
 category: Standard
@@ -12,7 +12,7 @@ feature: (fill in with feature key and github tracking issues once accepted)
 
 ## Summary
 
-Increase the maximum account info length for cross-program invoked (CPI)
+Increase the maximum number of account info's for cross-program invoked (CPI)
 instructions from 64 to 255 and consume compute units for serialized account
 info's and instruction account meta's.
 
@@ -62,6 +62,10 @@ The total cost of account info's can be computed with
 `(account_info_size * account_infos_len) / cpi_bytes_per_unit` rounded down to
 the nearest CU.
 
+Note that the SVM can skip duplicate or unused account info's but for simpler CU
+accounting, each account info has the same effect on cost regardless of whether
+it's actually used by the invoked instruction.
+
 ### Instruction Account Metadata Cost
 
 Consume **1 compute unit (CU)** for every `cpi_bytes_per_unit` (currently 250)
@@ -77,6 +81,19 @@ The total cost of instruction account metadata can be computed with
 `(ix_account_metadata_size * ix.accounts.len()) / cpi_bytes_per_unit` rounded
 down to the nearest CU.
 
+### Reduce base CPI cost
+
+The base cost of CPI syscalls is currently set to 1000 compute units. In order
+to avoid charging more CU's for existing onchain program behavior after the
+activation of this feature, the base cost of CPI syscalls will decreased by 54
+compute units to 946 compute units to offset the new costs.
+
+Before this SIMD, up to 255 instruction account metadata's could be passed to a
+CPI syscall. The base cost offset is therefore `255 * 34 / 250 = 34` CU's.
+
+Before this SIMD, up to 64 account info's could be passed to a CPI syscall.
+The base cost offset is therefore `64 * 80 / 250 = 20` CU's.
+
 ## Alternatives Considered
 
 What alternative designs were considered and what pros/cons does this feature
@@ -86,11 +103,15 @@ have relative to them?
 
 Since the list of account info's passed to a CPI can now be ~4 times longer,
 there will be more overhead in the SVM to map each instruction account address
-to one of the account info's and translate account info's to callee instruction
-accounts.
+to one of the account info's.
 
-CPI's will consume additional compute units proportional to the number of
-account info's and instruction accounts.
+The number of allowed unique account info's remains unchanged so the maximum
+amount of accounts that need to be translated for a CPI syscall has not
+increased.
+
+CPI's will consume compute units proportional to the number of account info's
+and instruction accounts. This gives an extra incentive to onchain programs
+to decrease the number of accounts passed to CPI's.
 
 ## Security Considerations
 
@@ -104,5 +125,4 @@ Why should we not do this?
 
 The max account info length increase for CPI's and new costs will be feature
 gated. Since the limit is being increased, existing behavior will not be
-restricted. However, new imposed costs for CPI instruction accounts and account
-info's may cause onchain programs to consume additional CU's.
+restricted.


### PR DESCRIPTION
Suggested by @Arrowana
> [the CPI max account info limit] is actually quite the pain because [at the] top level the compression allow for repeating accounts a lot, but then [..] for cpi purposes we can't

> Ideally cpi is never more restrictive than the top level to prevent this kind of limitation