### PR TITLE
fixed few typos

### DIFF
--- a/proposals/0332-cha-cha-8.md
+++ b/proposals/0332-cha-cha-8.md
@@ -50,7 +50,7 @@ block data out.
 If someone could predictably grind and influence turbine tree to ensure some
 malicious minority of stake could censor unrecoverable portions of a block, this
 would be a problem. Today, the grinding can be done, which means further ChaCha
-rounds provide very limited beenfit, but the ability to influence the generated
+rounds provide very limited benefit, but the ability to influence the generated
 tree is clamped down because the input data includes:
 
 - shred index

--- a/proposals/0334-fix-alt-bn128-pairing-length-check.md
+++ b/proposals/0334-fix-alt-bn128-pairing-length-check.md
@@ -63,7 +63,7 @@ pub fn alt_bn128_pairing(input: &[u8]) -> Result<Vec<u8>, AltBn128Error> {
 }
 ```
 
-The correct logic should check that the reminder is 0.
+The correct logic should check that the remainder is 0.
 
 ```rust
 pub fn alt_bn128_pairing(input: &[u8]) -> Result<Vec<u8>, AltBn128Error> {


### PR DESCRIPTION
1. Fixed typo in proposal [0332-cha-cha-8.md](https://github.com/solana-foundation/solana-improvement-documents/commit/cd526c2a94b39941d18a86b5c918a633d6df9f9d): beenfit → benefit
2. Fixed typo in proposal [0334-fix-alt-bn128-pairing-length-check.md](https://github.com/solana-foundation/solana-improvement-documents/commit/9c3e96ab073698daa62921f52ccb672d26c71e1a): reminder is 0 → remainder is 0