### PR TITLE
chore: update GitHub Actions versions and improve CI performance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout SIMD Repository
-        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+        uses: actions/checkout@v5
 
       - name: Get Changed Files
         id: changed
@@ -28,24 +28,28 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Lint
-        uses: DavidAnson/markdownlint-cli2-action@16d9da45919c958a8d1ddccb4bd7028e8848e4f1
+        uses: DavidAnson/markdownlint-cli2-action@v20
         if: steps.changed.outcome == 'success'
         with:
           command: config
           globs: |
             .github/config/.markdownlint.yaml
             ${{ env.CHANGED_FILES }}
+
   customSIMDLint:
+    name: Custom SIMD Linter
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [18.x, 20.x]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-      - run: npm install
+          cache: npm
+          cache-dependency-path: package-lock.json
+      - run: npm ci
       - run: npm run lint


### PR DESCRIPTION
## Description

Update GitHub Actions versions and improve CI performance.

## Changes Made

- Updated `actions/checkout` to `@v5`
- Updated `actions/setup-node` to `@v4` with npm caching
- Updated `markdownlint-cli2-action` to `@v20`
- Changed `npm install` to `npm ci`
- Added Node.js 20.x to test matrix

## Benefits

- Faster builds with npm caching
- Latest security patches
- More reliable dependency installation
- Better compatibility testing