### PR TITLE
SIMD-0366: Enforce `DATA_COMPLETE_SHRED` Placement only on Last Data Shreds in FEC Sets

### DIFF
--- a/proposals/0366-enforce-data-complete-shred-placement.md
+++ b/proposals/0366-enforce-data-complete-shred-placement.md
@@ -38,7 +38,12 @@ ambiguity creates significant performance challenges:
 2. **Performance Impact**: alternative `BlockComponent` methods require either
    complex inference algorithms or expensive replay operations.
 
-3. **Security Vulnerabilities**: Malicious leaders could intentionally
+3. **Complexity**: there is extra code complexity in storing the data complete
+   ranges for deserialization in replay. With this change and SIMD-0317 (fixed
+   32:32 FEC sets), it becomes really easy to figure out the ranges
+   to deserialize for replay.
+
+4. **Security Vulnerabilities**: Malicious leaders could intentionally
    misplace `DATA_COMPLETE_SHRED` flags to force validators into expensive
    search operations, creating DoS attack vectors; for certain proposed
    `BlockComponent`s (specifically, `UpdateParent`), malicious leaders could


### PR DESCRIPTION
## Summary

This SIMD enforces that the `DATA_COMPLETE_SHRED` flag can only be set on the final data shred within an FEC (Forward Error Correction) set. One key use-case for this SIMD: this restriction enables efficient detection of soon-to-be-introduced `BlockComponent`s at shred ingestion time, providing performance improvements for critical consensus operations. The alternative to this SIMD would be to detect `BlockComponent`s during replay, which would be substantially slower. One key example is `UpdateParent` detection in Alpenglow's fast leader handover; detection during replay would not be ideal, as malicious leaders could intentionally misplace `DATA_COMPLETE_SHRED` flags to force validators into expensive search operations, creating DoS attack vectors and delaying block repairs.

## Motivation

Currently, the `DATA_COMPLETE_SHRED` flag can theoretically be set on any data shred within an FEC set, though in practice it marks FEC set boundaries. This ambiguity creates significant performance challenges:

1. **Expensive BlockComponent Detection**: Without guaranteed placement, detecting `BlockComponent`s requires expensive searches across multiple shreds and FEC sets.

2. **Performance Impact**: alternative `BlockComponent` methods require either complex inference algorithms or expensive replay operations.

3. **Security Vulnerabilities**: Malicious leaders could intentionally misplace `DATA_COMPLETE_SHRED` flags to force validators into expensive search operations, creating DoS attack vectors; for certain proposed `BlockComponent`s (specifically, `UpdateParent`), malicious leaders could delay block repairs for following leaders.

By enforcing `DATA_COMPLETE_SHRED` placement only on the last data shred in each FEC set, validators can efficiently detect `BlockComponent` boundaries during online shred ingestion.