### PR TITLE
SIMD-0371: Alpenglow Fast Handoff Marker

### DIFF
--- a/proposals/0371-alpenglow-fast-handoff-marker.md
+++ b/proposals/0371-alpenglow-fast-handoff-marker.md
@@ -14,7 +14,7 @@ feature: TBD
 
 ## Summary
 
-(This combines and replaces SIMDs 337 and 366.)
+(This replaces and extends SIMDs 337 and 366.)
 Upgrade `BlockMarkerV1` from SIMD-0307 to `BlockMarkerV2`, introducing
 `BlockHeader` and `UpdateParent` variants. `BlockHeader` is placed at the
 beginning of block payload and indicates the parent of a block. `UpdateParent`


### PR DESCRIPTION
(This replaces and extends SIMDs 337 and 366.)
Upgrade `BlockMarkerV1` from SIMD-0307 to `BlockMarkerV2`, introducing
`BlockHeader` and `UpdateParent` variants. `BlockHeader` is placed at the
beginning of block payload and indicates the parent of a block. `UpdateParent`
signals that the intended parent is different than initially indicated. This
paves the way for Fast Leader Handoff support in Alpenglow (section 2.7 of
https://www.anza.xyz/alpenglow-1-1), increasing throughput.