### PR TITLE
SIMD-0385: Transaction V1 Format

### DIFF
--- a/proposals/0385-transaction-v1.md
+++ b/proposals/0385-transaction-v1.md
@@ -53,9 +53,9 @@ sizes.
 ```
 VersionByte (u8)
 LegacyHeader (u8, u8, u8) 
-NumInstructions (u8)
 TransactionConfigMask (u32) -- Bitmask of which config requests are present.
 LifetimeSpecifier [u8; 32]
+NumInstructions (u8)
 NumAddresses (u8)
 Addresses [[u8; 32]] -- Length matches NumAddresses
 ConfigValues [[u8; 4]] -- Length equal to the popcount (number of set bits)


### PR DESCRIPTION
I have separated the Transaction V1 format from the larger transaction size SIMD #296. Both of these SIMDs would eventually have the same feature gate if they are accepted.