### PR TITLE
Specify that subgroup check is skipped for add in SIMD-0302

### DIFF
--- a/proposals/0302-bn254-g2-syscalls.md
+++ b/proposals/0302-bn254-g2-syscalls.md
@@ -76,6 +76,29 @@ included use the little-endian encoding conventions as specified in
 [SIMD-0284](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0284-alt-bn128-little-endian.md),
 consistent with existing BN128 syscalls.
 
+### Validation and Subgroup Checks
+
+The validation requirements for the new G2 operations are defined as follows to
+balance safety and compute cost, consistent with the approach for BLS12-381:
+
+1. _G2 Addition (`ALT_BN128_G2_ADD`) and Subtraction (`ALT_BN128_G2_SUB`)_:
+   - Input points MUST be validated to ensure they are on the curve (satisfy
+     the G2 curve equation).
+   - The _subgroup check is skipped_. The addition formulas are valid for
+     any point on the curve (including those not in the prime-order subgroup).
+     Skipping this costly check allows for cheaper accumulation of points.
+
+2. _G2 Scalar Multiplication (`ALT_BN128_G2_MUL`)_:
+   - Input points MUST undergo _full validation_, including the field check,
+     curve equation check, and the _subgroup check_.
+   - Enforcing the subgroup check is required to safely support faster
+     endomorphism-based scalar multiplication algorithms.
+
+_Note on G1_: For the existing G1 operations, the BN254 (Alt-BN128) curve has
+a cofactor of 1. This means that every point satisfying the curve equation is
+automatically in the prime-order subgroup. Therefore, no separate subgroup
+check is needed for G1 as the on-curve check is sufficient.
+
 ## Alternatives Considered
 
 - Separate G2‑only syscall entrypoint rather than extending sol_alt_bn128_group_op.


### PR DESCRIPTION
Specify the fact that the subgroup check should be skipped for the addition syscall for alt_bn128.

cc: @0x0ece, @zz-sol, @Rexicon226