### PR TITLE
Update SIMD-406

### DIFF
--- a/proposals/0406-maximum-instruction-accounts.md
+++ b/proposals/0406-maximum-instruction-accounts.md
@@ -8,7 +8,7 @@ category: Standard
 type: Core
 status: Review
 created: 2025-11-19
-feature: (fill in with feature tracking issues once accepted)
+feature: DqbnFPASg7tHmZ6qfpdrt2M6MWoSeiicWPXxPhxqFCQ
 ---
 
 ## Summary
@@ -42,10 +42,9 @@ None.
 A new verification step must be included in message sanitization for message 
 formats legacy and v0. The verification step must examine every instruction in 
 a transaction, check if the former references more than 255 accounts, and 
-throw `SanitizationError::ValueOutOfBounds` otherwise. Transactions violating 
-such a restriction must be considered invalid and not included in a block. 
-Likewise, blocks containing transactions that violate such condition should be 
-declared dead.
+throw an error otherwise. Transactions violating such a restriction must be 
+considered invalid and not included in a block. Likewise, blocks containing 
+transactions that violate such condition should be declared dead.
 
 Transactions in the v1 format 
 ([SIMD-0385](https://github.com/solana-foundation/solana-improvement-documents/pull/385))


### PR DESCRIPTION
This PR amends the SIMD with the feature gate key and removes the error type from the detailed design section. During the implementation, we noticed we should not specify the error type in the SIMD (see https://github.com/anza-xyz/agave/pull/10223#discussion_r2744635089)