### PR TITLE
amend SIMD-0464: add instruction discriminant, accounts, and SIMD-0232 checks

### DIFF
--- a/proposals/0464-vote-account-initialize-v2.md
+++ b/proposals/0464-vote-account-initialize-v2.md
@@ -94,6 +94,8 @@ pub enum VoteInstruction {
     /// # Account references
     ///   0. `[WRITE]` Uninitialized vote account
     ///   1. `[SIGNER]` New validator identity (node_pubkey)
+    ///   2. `[WRITE]` Inflation rewards collector (or vote account if same)
+    ///   3. `[WRITE]` Block revenue collector (or vote account if same)
     InitializeAccountV2(VoteInitV2), // 16u32
 }
 ```
@@ -109,17 +111,29 @@ pub struct VoteInitV2 {
   pub authorized_voter_bls_proof_of_possession: [u8; BLS_PROOF_OF_POSSESSION_COMPRESSED_SIZE],
   pub authorized_withdrawer: Pubkey,
   pub inflation_rewards_commission_bps: u16,
-  pub inflation_rewards_collector: Pubkey,
   pub block_revenue_commission_bps: u16,
-  pub block_revenue_collector: Pubkey,
 }
 ```
 
 Upon receiving the transaction, the vote program will perform a BLS
 verification on the submitted BLS public key and associated proof of
 possession, as described in [SIMD-0387]. The transaction will fail if the
-verification fails. Otherwise the new vote account is created with the given
-parameters.
+verification fails.
+
+For each collector account (indices `2` and `3`), the vote program MUST perform
+the following validation, matching the checks required by
+`UpdateCommissionCollector` in [SIMD-0232]:
+
+1. If the collector is not equal to the vote account, it must be system program
+   owned. Otherwise return `InstructionError::InvalidAccountOwner`.
+2. The collector must be rent-exempt. Otherwise return
+   `InstructionError::InsufficientFunds`.
+3. The collector must be writable (not a reserved account). Otherwise return
+   `InstructionError::InvalidArgument`.
+
+If all checks pass, the new vote account is created with the given parameters.
+The inflation rewards collector address is taken from account index `2` and the
+block revenue collector address is taken from account index `3`.
 
 The BLS PoP verification will cost 34,500 CUs, as described in [SIMD-0387].
 

--- a/proposals/0464-vote-account-initialize-v2.md
+++ b/proposals/0464-vote-account-initialize-v2.md
@@ -100,13 +100,13 @@ pub enum VoteInstruction {
 
 ```rust
 pub const BLS_PUBLIC_KEY_COMPRESSED_SIZE: usize = 48;
-pub const BLS_SIGNATURE_COMPRESSED_SIZE: usize = 96;
+pub const BLS_PROOF_OF_POSSESSION_COMPRESSED_SIZE: usize = 96;
 
 pub struct VoteInitV2 {
   pub node_pubkey: Pubkey,
   pub authorized_voter: Pubkey,
   pub authorized_voter_bls_pubkey: [u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE],
-  pub authorized_voter_bls_proof_of_possession: [u8; BLS_SIGNATURE_COMPRESSED_SIZE],
+  pub authorized_voter_bls_proof_of_possession: [u8; BLS_PROOF_OF_POSSESSION_COMPRESSED_SIZE],
   pub authorized_withdrawer: Pubkey,
   pub inflation_rewards_commission_bps: u16,
   pub inflation_rewards_collector: Pubkey,

--- a/proposals/0464-vote-account-initialize-v2.md
+++ b/proposals/0464-vote-account-initialize-v2.md
@@ -85,8 +85,17 @@ creation.
 
 ### Add InitializeAccountV2
 
+A new instruction for initializing a vote account with all vote state v4 fields
+will be added to the vote program with the enum discriminant value of `16u32`
+little endian encoded in the first 4 bytes.
+
 ```rust
-InitializeAccountV2(VoteInitV2),
+pub enum VoteInstruction {
+    /// # Account references
+    ///   0. `[WRITE]` Uninitialized vote account
+    ///   1. `[SIGNER]` New validator identity (node_pubkey)
+    InitializeAccountV2(VoteInitV2), // 16u32
+}
 ```
 
 ```rust


### PR DESCRIPTION
First updates the SIMD to specify the instruction discriminant and accounts. However, then we also needed to modify the input parameters as well as the accounts list in order to ensure that `InitializeAccountV2` imposes the same checks as `UpdateCommissionCollector` [as SIMD-0232 does](https://github.com/solana-foundation/solana-improvement-documents/blob/3713fb347ae02e3420a3f65f62900da831a5185a/proposals/0232-custom-commission-collector.md?plain=1#L105-L111).