### PR TITLE
build: Add `@types/node` and `markdownlint` to run jobs locally

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
   "homepage": "https://github.com/solana-foundation/solana-improvement-documents#readme",
   "devDependencies": {
     "@types/js-yaml": "^4.0.5",
+    "@types/node": "^25.3.5",
+    "markdownlint": "^0.27.0",
     "markdownlint-cli2": "^0.6.0",
     "ts-node": "^10.9.1",
     "typescript": "^4.9.5"


### PR DESCRIPTION
#### Problem

Running `npm i` or `pnpm i` and then `npm run lint` doesn't work currently, due to missing typescript types and transitive dependencies.

#### Summary of changes

Add the missing dependencies, which are `@types/node` for Typescript, and `markdownlint` v0.27.0, which is used by markdownlint-cli2 v0.6.0.

Note that CI uses commit `16d9da45919c958a8d1ddccb4bd7028e8848e4f1` of the markdownlint-cli2-action repo, which corresponds to version 0.4.0 of markdownlint-cli2.