### PR TITLE
nit: add Draft to allowed statuses

### DIFF
--- a/.github/linter/customRules.ts
+++ b/.github/linter/customRules.ts
@@ -282,6 +282,7 @@ export const metadataStatusIsValid = {
 
     const validStatus = [
       "Idea",
+      "Draft",
       "Review",
       "Accepted",
       "Stagnant",


### PR DESCRIPTION
`Draft` is specified in SIMD-0001 but the linter rejects it, i get bit by this every time :sweat_smile: 