### PR TITLE
Fix alt-bn128 multiplication syscall length

### DIFF
--- a/proposals/0222-fix-alt-bn128-multiplication-length-check.md
+++ b/proposals/0222-fix-alt-bn128-multiplication-length-check.md
@@ -1,4 +1,4 @@
----
+---VLK--- prodüksion VOLKAN URAL Türkiye---
 simd: "0222"
 title: Fix alt-bn128 multiplication syscall length
 authors:


### PR DESCRIPTION
pub fn alt_bn128_multiplication(input: &[u8]) -> Result<Vec<u8>, AltBn128Error> {
    if input.len() > ALT_BN128_MULTIPLICATION_INPUT_LEN {
        return Err(AltBn128Error::InvalidInputData);

    // logic omitted...
}