### PR TITLE
linter: add Advisory to valid category and type values

### DIFF
--- a/.github/linter/customRules.ts
+++ b/.github/linter/customRules.ts
@@ -226,7 +226,7 @@ export const metadataCategoryIsValid = {
     const category: string = frontMatter.category
     if (!category) return
 
-    if (!["Meta", "Standard"].includes(category)) {
+    if (!["Meta", "Standard", "Advisory"].includes(category)) {
       onError({
         lineNumber: 1,
         detail: `\`${category}\` is not supported as a value for category`,
@@ -251,7 +251,7 @@ export const metadataTypeIsValid = {
     const type: string = frontMatter.type
     if (!type) return
 
-    const validTypes = ["Core", "Networking", "Interface", "Meta"]
+    const validTypes = ["Core", "Networking", "Interface", "Meta", "Advisory"]
 
     if (!validTypes.some((validType) => type.includes(validType))) {
       onError({


### PR DESCRIPTION
https://github.com/solana-foundation/solana-improvement-documents/pull/484 introduced the Advisory SIMD type. Update the linter allowlists to accept it.