### PR TITLE
SIMD-506: Upgrade Agave secp256k1 syscall precompile to k256 (Agave-specific)

### DIFF
--- a/proposals/0505-upgrade-agave-secp256k1-to-k256.md
+++ b/proposals/0505-upgrade-agave-secp256k1-to-k256.md
@@ -1,6 +1,6 @@
 ---
-simd: "0505"
-title: Upgrade Agave secp256k1 syscall precompile to k256 (Agave-specific)
+simd: "0506"
+title: Upgrade secp256k1 to k256 (Agave-specific)
 authors:
   - Sam Kim
   - Zhenfei Zhang


### PR DESCRIPTION
Proposal to upgrade agave secp256k1 syscall and precompile implementation from using libsecp256k1, which is unmaintained, to the k256 crate.

This is an agave specific upgrade, which we hope to do behind a feature gate. We already had discussions with @0x0ece, @drubin-fd, and @jacobcreech. We'd like to express appreciation to the Firedancer team for their flexibility in accommodating an Agave-specific feature gate.