### PR TITLE
Remove mentions to the verifier from SIMD-178

### DIFF
--- a/proposals/0178-static-syscalls.md
+++ b/proposals/0178-static-syscalls.md
@@ -67,9 +67,7 @@ should look like `85 00 00 00 11 1a fc b6`.
 
 Consequently, system calls in the Solana SDK and in any related compiler tools 
 must be registered as function pointers, whose address is the murmur32 hash of 
-their name. The bytecode verifier must enforce that the immediate value of a 
-syscall instruction points to a valid syscall, and throw 
-`VerifierError::InvalidSyscall` otherwise.
+their name.
 
 This new instruction comes together with modifications in the semantics of 
 the instruction opcode `0x85` with source register set to one, which  must 


### PR DESCRIPTION
We had decided to wind down the byte code verifier from the protocol, starting with sbpfv3, but I left a reference to it in the SIMD that should not exist.

That part is not implemented and is not part of the proposal.