### PR TITLE
SIMD-0186: Define fee-only semantics

### DIFF
--- a/proposals/0186-loaded-transaction-data-size-specification.md
+++ b/proposals/0186-loaded-transaction-data-size-specification.md
@@ -89,13 +89,16 @@ Transactions may include a
 a lower data size limit for the transaction. Otherwise, the default limit is
 64MiB (`64 * 1024 * 1024` bytes).
 
-If a transaction loading failure occurs due to exceeding its requested data size
-limit, its loaded transaction data size is defined as that requested data size
-limit.
+If transaction account loading fails by exceeding the requested data size limit,
+the final loaded transaction data size is defined as the requested data size
+limit itself. This ensures that account load order is *not* part of
+consensus: validator clients may load accounts in any order, in serial or
+parallel, and arrive at the same failure result.
 
-If transaction account loading completes successfully, but a transaction loading
-failure occurs subsequently due to the rules defined in "Sidebar: Program ID and
-Loader Validation," its calculated loaded transaction data size is used.
+*After* all transaction accounts have been loaded, the actual loaded size as
+defined by the the four rules of "Detailed Design" above is used for the
+transaction. This means that a post-account loading failure, such as described
+by "Sidebar: Program ID and Loader Validation," reports the actual loaded size.
 
 The loaded transaction data size of a committed no-op transaction, as would be
 introduced by

--- a/proposals/0186-loaded-transaction-data-size-specification.md
+++ b/proposals/0186-loaded-transaction-data-size-specification.md
@@ -89,11 +89,20 @@ Transactions may include a
 a lower data size limit for the transaction. Otherwise, the default limit is
 64MiB (`64 * 1024 * 1024` bytes).
 
-If a transaction exceeds its data size limit, a loading failure occurs. This
-SIMD does not change any aspect of how such a failure is handled. At time of
-writing, such a transaction would be excluded from the ledger. When
-`enable_transaction_loading_failure_fees` is enabled, it will be written to the
-ledger and charged fees as a processed, failed transaction.
+If a transaction loading failure occurs due to exceeding its requested data size
+limit, its loaded transaction data size is defined as that requested data size
+limit.
+
+If transaction account loading completes successfully, but a transaction loading
+failure occurs subsequently due to the rules defined in "Sidebar: Program ID and
+Loader Validation," its calculated loaded transaction data size is used.
+
+The loaded transaction data size of a committed no-op transaction, as would be
+introduced by
+[SIMD-290](https://github.com/solana-foundation/solana-improvement-documents/pull/290)
+and
+[SIMD-297](https://github.com/solana-foundation/solana-improvement-documents/pull/297)
+is intentionally left unspecified.
 
 Adding required loaders to transaction data size is abolished. They are treated
 the same as any other account: counted if used in a manner described by 1, not


### PR DESCRIPTION
this has been discussed internally and the concept has firedancer buy-in, we left fee-only behavior underspecified since this simd was originally written before fee-only transactions were enabled. there is presently a weird quirk where the raw (pre-186) sizes of rollback accounts are used for LTDS. this is a straightforwardly sane and normal improvement

i defined fee/nonce relaxation behavior as unspecified as these implementations are stalled pending nonce removal and it isnt immediately obvious what to do with them