### PR TITLE
[SIMD-0388] Specify that the pairing length will be bounded by 8

### DIFF
--- a/proposals/0388-bls12-381-syscalls.md
+++ b/proposals/0388-bls12-381-syscalls.md
@@ -274,7 +274,9 @@ define_syscall!(fn sol_curve_pairing_map(
 ```
 
 The `num_pairs` parameter specifies the number of G1/G2 pairs to be processed.
-The `g1_points` and `g2_points` parameters are pointers to memory buffers.
+To ensure bounded execution time and prevent excessive compute consumption,
+num_pairs is strictly bounded to a maximum of 8. The `g1_points` and `g2_points`
+parameters are pointers to memory buffers.
 
 The syscall will read `num_pairs` from each buffer. It must read:
 


### PR DESCRIPTION
Add detail on the maximum bound on the number of BLS12-381 pairings that can be computed on a single call. To ensure bounded execution time and prevent excessive compute consumption, we should bound BLS12-381 syscall function to process at most 8 number of pairings at once.