### PR TITLE
fix: correct spelling errors in SIP proposals

### DIFF
--- a/proposals/0048-native-program-for-secp256r1-sigverify.md
+++ b/proposals/0048-native-program-for-secp256r1-sigverify.md
@@ -27,7 +27,7 @@ doesn't just airgap your private key with a hardware wallet (which even then
 remains as a single point of failure). Arguably, multi-signature wallets fit
 into this equation as they enable the dependency on multiple private keys.
 However in practice the UX takes too much of a hit, as having to sign a
-transaction a minimum of 3 seperate times and having to write down 3 seed
+transaction a minimum of 3 separate times and having to write down 3 seed
 phrases is too cumbersome. It would be ideal to have an authetication form that
 relies on a more familiar second factor, such as a users mobile device.
 

--- a/proposals/0204-slashable-event-verification.md
+++ b/proposals/0204-slashable-event-verification.md
@@ -90,7 +90,7 @@ system program :
 - `offset`, an unaligned eight-byte little-endian unsigned integer indicating
   the offset from which to read the proof
 - `slot`, an unaligned eight-byte little-endian unsigned integer indicating the
-  slot in which the violation occured
+  slot in which the violation occurred
 - `node_pubkey`, an unaligned 32 byte array representing the public key of the
   node which committed the violation
 - `reporter`, an unaligned 32 byte array representing the account to credit
@@ -262,7 +262,7 @@ struct ProofReport {
 
   slot: Slot,                      // Unaligned unsigned eight-byte little endian
                                    // integer representing the slot in which the
-                                   // violation occured
+                                   // violation occurred
 
   violation_type: u8,              // Byte representing the violation type
 }


### PR DESCRIPTION
## Description
Fixed spelling errors in Solana Improvement Proposal documents.

⚠️ **Note:** Documentation-only changes. No functional code modified.

## Changes
- Fix 'seperate' → 'separate'
- Fix 'occured' → 'occurred'

## Files Modified
- proposals/0048-native-program-for-secp256r1-sigverify.md
- proposals/0204-slashable-event-verification.md

## Impact
- Documentation clarity improvement only
- No changes to proposal specifications or implementations