### PR TITLE
SIMD-0064 Transaction Receipts — picking this up, Groth16 Merkle inclusion extension

### DIFF
--- a/proposals/0064-transaction-receipt.md
+++ b/proposals/0064-transaction-receipt.md
@@ -430,37 +430,45 @@ compatibility concerns.
 
 ## Update — 2026-05-31
 
-Picking this up. — sls_0x / Parad0x Labs (https://github.com/Parad0x-Labs/dna-x402)
+Picking this up. — sls_0x / Parad0x Labs
+(https://github.com/Parad0x-Labs/dna-x402)
 
 ### Why
 
-We built x402 payment receipts for AI agents on Solana. The application layer
-is live on mainnet: `receipt_anchor` (`6HSRGivdYR5D7yTDy1TFMCM8h3LzXxRtKU1RA3RnCMRN`)
-anchors 32-byte receipt hashes in hourly Merkle buckets on-chain. The missing
-piece is block-level inclusion proof so downstream verifiers do not have to trust
+We built x402 payment receipts for AI agents on Solana. The application
+layer is live on mainnet: `receipt_anchor`
+(`6HSRGivdYR5D7yTDy1TFMCM8h3LzXxRtKU1RA3RnCMRN`) anchors 32-byte
+receipt hashes in hourly Merkle buckets on-chain. The missing piece is
+block-level inclusion proof so downstream verifiers do not have to trust
 an RPC.
 
-We also have `dark_bn254_gate` (`GCptvBYF8S6eVYoh15B7WAESc54FUHCpN1Ui6aHeQYZd`)
-live on mainnet — a Groth16 BN254 verifier using the native `alt_bn128_pairing`
-syscall at ~200k CU. This is the on-chain primitive for the ZK extension below.
+We also have `dark_bn254_gate`
+(`GCptvBYF8S6eVYoh15B7WAESc54FUHCpN1Ui6aHeQYZd`) live on mainnet — a
+Groth16 BN254 verifier using the native `alt_bn128_pairing` syscall at
+~200k CU. This is the on-chain primitive for the ZK extension below.
 
 ### Proposed optional extension: Groth16 Merkle inclusion proof
 
-Intent to specify — not a finished spec. Open questions are called out explicitly.
+Intent to specify — not a finished spec. Open questions called out below.
 
 **Variable block size — fixed MAX_DEPTH:**
 Groth16 circuits are parameterised at ceremony time and cannot change after the
 fact. Solana block transaction counts vary widely, so the circuit must target a
 hardcoded maximum depth. Proposed: `MAX_DEPTH = 20` (up to 2^20 ≈ 1M
-transactions per block). Smaller blocks pad empty leaves with `H(0)`. One
+transactions per block). Smaller blocks pad empty leaves with `H(0)` where
+`H(0)` is defined as the hash function applied to a 32-byte all-zero input.
+This resolves deterministically: `SHA-256(0x00...00)` or
+`Poseidon(0, 0)` depending on the hash function chosen above. All
+implementations must agree on this value or Merkle roots will diverge. One
 circuit, one ceremony, covers all valid block sizes within that bound. Blocks
-exceeding the depth limit fall back to the existing hash-chain proof variant.
+exceeding the depth limit fall back to the SIMD-0064 hash-chain inclusion proof
+(Sections 4–6 of this document), which has no depth constraint.
 
 **Hash function (open question — needs working group input):**
 The SIMD-0064 receipt tree uses SHA-256. SHA-256 inside a Groth16 circuit costs
 ~27k constraints per hash. A ZK-friendly hash (e.g. Poseidon over BN254) is
 ~100x cheaper but produces a different root that diverges from the existing
-SHA-256 tree — it cannot reuse that root directly. Two paths: (a) keep SHA-256,
+SHA-256 tree — cannot reuse that root. Two paths: (a) keep SHA-256,
 accept the higher constraint count, reuse the existing tree root; (b) add a
 parallel Poseidon commitment to the block header alongside the SHA-256 hash.
 The right choice depends on what validators can feasibly commit in the header.
@@ -483,14 +491,14 @@ participant destroyed their toxic waste, the setup is sound. For a settlement
 use case we would run a larger public ceremony before deploying.
 
 **Proposed public inputs:**
-- `receipt_tree_root` — root of the fixed-depth receipt tree (hash function TBD, see above)
-- `tx_hash` — the leaf value as defined in SIMD-0064: `H(TransactionReceiptData)` where H
-  is the same hash function used to build the tree. Using the SIMD-0064 leaf definition
-  means any verifier can compute `tx_hash` independently from a transaction they observe
-  on-chain, without out-of-band context. If the hash function resolves to Poseidon, this
-  is `Poseidon(TransactionReceiptData)`; if SHA-256, `SHA-256(TransactionReceiptData)`.
-  The private witness supplies the Merkle auth-path (sibling hashes and direction bits
-  for each of the MAX_DEPTH levels) that connects this leaf to `receipt_tree_root`.
+
+- `receipt_tree_root` — root of the fixed-depth receipt tree
+  (hash function TBD, see above)
+- `tx_hash` — the leaf value per SIMD-0064: `H(TransactionReceiptData)`
+  using the same H as the tree. Any verifier can recompute this from an
+  observed transaction without out-of-band context.
+  Private witness: Merkle auth-path (MAX_DEPTH sibling hashes + direction
+  bits) connecting this leaf to `receipt_tree_root`.
 - `block_header_hash` — binds the proof to a specific block
 
 **What we are not touching:**
@@ -502,7 +510,8 @@ We own the on-chain verifier and client SDK.
 
 1. Resolve hash function choice with the working group (SHA-256 vs Poseidon)
 2. Formalise `MAX_DEPTH` and the empty-leaf padding rule
-3. Define which block-header field carries the receipt tree root (needs validator input)
+3. Define which block-header field carries the receipt tree root
+   (needs validator input)
 4. Implement the fixed-depth Merkle inclusion circuit (Circom)
 5. Run a public multi-party ceremony for the new circuit
 6. Produce test vectors against devnet blocks

--- a/proposals/0064-transaction-receipt.md
+++ b/proposals/0064-transaction-receipt.md
@@ -483,8 +483,14 @@ participant destroyed their toxic waste, the setup is sound. For a settlement
 use case we would run a larger public ceremony before deploying.
 
 **Proposed public inputs:**
-- `receipt_tree_root` — root of the fixed-depth receipt tree (hash function TBD)
-- `tx_hash` — hash of the transaction receipt being proved
+- `receipt_tree_root` — root of the fixed-depth receipt tree (hash function TBD, see above)
+- `tx_hash` — the leaf value as defined in SIMD-0064: `H(TransactionReceiptData)` where H
+  is the same hash function used to build the tree. Using the SIMD-0064 leaf definition
+  means any verifier can compute `tx_hash` independently from a transaction they observe
+  on-chain, without out-of-band context. If the hash function resolves to Poseidon, this
+  is `Poseidon(TransactionReceiptData)`; if SHA-256, `SHA-256(TransactionReceiptData)`.
+  The private witness supplies the Merkle auth-path (sibling hashes and direction bits
+  for each of the MAX_DEPTH levels) that connects this leaf to `receipt_tree_root`.
 - `block_header_hash` — binds the proof to a specific block
 
 **What we are not touching:**

--- a/proposals/0064-transaction-receipt.md
+++ b/proposals/0064-transaction-receipt.md
@@ -500,17 +500,21 @@ use case we would run a larger public ceremony before deploying.
 
 - `receipt_tree_root` — root of the fixed-depth receipt tree
   (hash function TBD, see above)
-- `tx_hash` — the leaf value per SIMD-0064: `H(TransactionReceiptData)`
-  using the same H as the tree. Any verifier can recompute this from an
-  observed transaction without out-of-band context.
-  Private witness: Merkle auth-path (MAX_DEPTH sibling hashes + direction
-  bits) connecting this leaf to `receipt_tree_root`.
+- `tx_hash` — the leaf value of the dedicated ZK receipt tree.
+  SIMD-0064 defines its existing leaf as `sha256(0x00 || R)` where
+  R is the serialised `TransactionReceiptData`. The ZK tree uses the
+  same domain-separated construction: `H(0x00 || R)` with whatever H
+  is chosen above. This keeps the leaf encoding consistent with SIMD-0064
+  regardless of hash function. Private witness: MAX_DEPTH sibling hashes
+  and direction bits connecting this leaf to `receipt_tree_root`.
 - `block_header_hash` — binds the proof to a specific block
 
-**What we are not touching:**
-Agave or Firedancer internals. The validator side needs to (1) build the
-fixed-depth tree at block production and (2) commit the root to a header field.
-We own the on-chain verifier and client SDK.
+**Validator changes required:**
+This extension requires validators to build a second, fixed-depth receipt
+tree at block production and commit its root to a block-header field.
+That is a validator-side change. We are not implementing it — we are
+defining the spec so Agave and Firedancer teams can decide if and how to
+adopt it. We own the on-chain verifier and client SDK.
 
 ### What we are committing to
 

--- a/proposals/0064-transaction-receipt.md
+++ b/proposals/0064-transaction-receipt.md
@@ -464,15 +464,21 @@ circuit, one ceremony, covers all valid block sizes within that bound. Blocks
 exceeding the depth limit fall back to the SIMD-0064 hash-chain inclusion proof
 (Sections 4–6 of this document), which has no depth constraint.
 
-**Hash function (open question — needs working group input):**
-The SIMD-0064 receipt tree uses SHA-256. SHA-256 inside a Groth16 circuit costs
-~27k constraints per hash. A ZK-friendly hash (e.g. Poseidon over BN254) is
-~100x cheaper but produces a different root that diverges from the existing
-SHA-256 tree — cannot reuse that root. Two paths: (a) keep SHA-256,
-accept the higher constraint count, reuse the existing tree root; (b) add a
-parallel Poseidon commitment to the block header alongside the SHA-256 hash.
-The right choice depends on what validators can feasibly commit in the header.
-We are not deciding this here.
+**Hash function and tree compatibility:**
+The existing SIMD-0064 receipt tree pads non-power-of-2 leaf counts by
+duplicating the last real leaf (not with H(0)). A fixed-depth ZK tree
+using H(0) padding therefore produces a different root for virtually all
+blocks. Reusing the existing SIMD-0064 tree root in the ZK circuit is not
+feasible without changing the SIMD-0064 tree construction, which is a
+breaking change.
+
+The ZK extension therefore requires a **separate, dedicated receipt tree**
+committed in the block header alongside the existing one. The dedicated
+tree uses fixed-depth H(0) padding (defined above) and a TBD hash
+function. Inside the Groth16 circuit, SHA-256 costs ~27k constraints per
+hash; Poseidon over BN254 is ~100x cheaper. Either works if the header
+commits to the same root. The hash function choice is a question for the
+working group.
 
 **Block-header commitment (requires validator input):**
 The circuit takes the receipt tree root as a public input. For a verifier to

--- a/proposals/0064-transaction-receipt.md
+++ b/proposals/0064-transaction-receipt.md
@@ -428,41 +428,25 @@ compatibility concerns.
 
 ---
 
-## Update — 2026-05-31
+## Revival note (2026-05-31)
 
-Picking this up. — sls_0x / Parad0x Labs
-(https://github.com/Parad0x-Labs/dna-x402)
-
-### Why
-
-We built x402 payment receipts for AI agents on Solana. The application
-layer is live on mainnet: `receipt_anchor`
-(`6HSRGivdYR5D7yTDy1TFMCM8h3LzXxRtKU1RA3RnCMRN`) anchors 32-byte
-receipt hashes in hourly Merkle buckets on-chain. The missing piece is
-block-level inclusion proof so downstream verifiers do not have to trust
-an RPC.
-
-We also have `dark_bn254_gate`
-(`GCptvBYF8S6eVYoh15B7WAESc54FUHCpN1Ui6aHeQYZd`) live on mainnet — a
-Groth16 BN254 verifier using the native `alt_bn128_pairing` syscall at
-~200k CU. This is the on-chain primitive for the ZK extension below.
+Revived by sls_0x (Parad0x Labs) after the proposal went stagnant in 2024.
+Motivation: x402 micropayment receipts for AI agents need a block-level
+inclusion proof so a downstream verifier does not have to trust an RPC.
+Deployment context and mainnet program references are in the PR
+description rather than this spec body.
 
 ### Planned extension: ZK inclusion proof (separate discussion)
 
-Beyond the hash-chain proof above, we intend to propose an optional
-Groth16/BN254 Merkle inclusion proof: prove a transaction's inclusion
-without revealing its position in the block. The on-chain verifier
-primitive already exists — `dark_bn254_gate` is live on mainnet and runs
-the BN254 pairing via `alt_bn128_pairing` at ~200k CU.
-
-This is **not specified in this PR.** It depends on design choices that
-belong in a dedicated SIMD discussion, not a final-spec change. The open
-questions we have identified so far:
+An optional Groth16/BN254 Merkle inclusion proof — prove a transaction's
+inclusion without revealing its position — is under consideration as a
+*separate* future proposal. It is **not specified in this PR** and depends
+on design choices that belong in a dedicated SIMD discussion. Open
+questions to resolve first:
 
 - **Fixed vs. variable depth.** Groth16 constraint systems are fixed at
-  ceremony time, but block transaction counts vary widely. A single
-  circuit needs a fixed maximum depth with a defined padding and overflow
-  rule.
+  ceremony time, but block transaction counts vary widely. A circuit needs
+  a fixed maximum depth with a defined padding and overflow rule.
 - **Hash function.** SHA-256 matches the existing tree but is expensive in
   a circuit (~27k constraints/hash). A ZK-friendly hash such as Poseidon is
   far cheaper but needs a canonical byte-to-field encoding and a separate
@@ -470,9 +454,6 @@ questions we have identified so far:
 - **Header commitment.** The tree root must be committed in a block-header
   field for light clients to trust it. Which field is validator-side and
   needs Anza / Firedancer input.
-- **Trusted setup.** A new circuit needs its own multi-party ceremony; our
-  existing ceremonies are for different circuits.
+- **Trusted setup.** A new circuit needs its own multi-party ceremony.
 
-We will bring this as a separate discussion with a complete design once
-those are resolved, per the SIMD process. The working sketch, our existing
-circuits, and ceremony transcripts live in the DNA x402 repo linked above.
+These will be raised as a dedicated SIMD discussion per the process.

--- a/proposals/0064-transaction-receipt.md
+++ b/proposals/0064-transaction-receipt.md
@@ -501,12 +501,17 @@ use case we would run a larger public ceremony before deploying.
 - `receipt_tree_root` — root of the fixed-depth receipt tree
   (hash function TBD, see above)
 - `tx_hash` — the leaf value of the dedicated ZK receipt tree.
-  SIMD-0064 defines its existing leaf as `sha256(0x00 || R)` where
-  R is the serialised `TransactionReceiptData`. The ZK tree uses the
-  same domain-separated construction: `H(0x00 || R)` with whatever H
-  is chosen above. This keeps the leaf encoding consistent with SIMD-0064
-  regardless of hash function. Private witness: MAX_DEPTH sibling hashes
-  and direction bits connecting this leaf to `receipt_tree_root`.
+  If SHA-256: `sha256(0x00 || R)` matching the SIMD-0064 leaf exactly,
+  where R is the serialised `TransactionReceiptData`.
+  If Poseidon: the byte string R is chunked into 31-byte blocks,
+  each interpreted as a little-endian BN254 Fr field element (standard
+  for BN254 Poseidon implementations such as iden3/circomlibjs and
+  the Poseidon syscall in SIMD-0359). Domain separation uses a
+  capacity element of 1 (distinct from the nullifier domain). Two
+  implementations must agree on this encoding or roots diverge; this
+  is an open question if Poseidon is chosen.
+  Private witness: MAX_DEPTH sibling hashes and direction bits
+  connecting this leaf to `receipt_tree_root`.
 - `block_header_hash` — binds the proof to a specific block
 
 **Validator changes required:**

--- a/proposals/0064-transaction-receipt.md
+++ b/proposals/0064-transaction-receipt.md
@@ -424,3 +424,59 @@ Further conerns include:
 
 This change does not impact the Solana ledger, and thus introduces no backwards
 compatibility concerns.
+
+---
+
+## Revival Notice — 2026-05-31
+
+**New implementation champions:** Parad0x Labs / sls_0x  
+**Status change:** Stagnant → Active (revival)  
+**Contact:** github.com/Parad0x-Labs / github.com/Parad0x-Labs/dna-x402
+
+### Why we're reviving this
+
+AI agents making micropayments via the x402 protocol need lightweight, trustless
+receipt verification. Today the only options are: trust an RPC, or run a full
+validator. SIMD-0064 provides a third path: a compact proof that a transaction
+was included in a specific block, verifiable by anyone holding the block header.
+
+We have an application-layer implementation already live on Solana mainnet:
+
+- **`receipt_anchor` program** (`6HSRGivdYR5D7yTDy1TFMCM8h3LzXxRtKU1RA3RnCMRN`):
+  accumulates 32-byte SHA-256 anchors into hourly-windowed `AnchorBucket` PDAs,
+  each holding a running Merkle root. This is the application layer that needs
+  SIMD-0064's block-level inclusion proof underneath it.
+
+- **`dark_bn254_gate` program** (`GCptvBYF8S6eVYoh15B7WAESc54FUHCpN1Ui6aHeQYZd`):
+  a live Groth16 BN254 verifier using Solana's native `alt_bn128_pairing` syscall.
+  This is the cryptographic primitive for the ZK extension described below.
+
+- **DNA x402 repo**: https://github.com/Parad0x-Labs/dna-x402
+
+### Proposed extension: Groth16 Merkle inclusion proof variant
+
+We propose adding an optional ZK variant alongside the existing hash-chain proof:
+
+- **Circuit:** proves `leaf ∈ Merkle-tree(block_entries)` without revealing the leaf position
+- **Public inputs:** block header hash, transaction hash, tree root
+- **Proof system:** Groth16 over BN254 — matches Solana's existing `alt_bn128` syscalls
+- **On-chain verification:** ~200k CU via the native precompile (demonstrated in `dark_bn254_gate`)
+- **Use case:** privacy-preserving payment channels and agent-to-agent settlements where
+  position metadata leaks are unacceptable
+
+### What we're committing to
+
+1. Update this SIMD with the ZK variant as a formally specified extension
+2. Implement the Merkle inclusion circuit (Circom, 2-party ceremony already completed
+   for our existing circuits — see `evidence/zk/ceremony-v2.json`)
+3. Produce RFC-style test vectors against devnet blocks
+4. Coordinate with Firedancer/Agave teams on the proof interface spec
+
+We are **not** proposing changes to Agave or Firedancer internals. Our scope is
+on-chain verification and the application SDK — we will define the proof interface
+that validators would need to produce, not implement the validator side.
+
+### Connection to grant application
+
+We have an open Solana Foundation grant application ($65k — external audit + ZK
+sprint + Squads multisig). This SIMD revival is part of that grant scope.

--- a/proposals/0064-transaction-receipt.md
+++ b/proposals/0064-transaction-receipt.md
@@ -503,13 +503,11 @@ use case we would run a larger public ceremony before deploying.
 - `tx_hash` — the leaf value of the dedicated ZK receipt tree.
   If SHA-256: `sha256(0x00 || R)` matching the SIMD-0064 leaf exactly,
   where R is the serialised `TransactionReceiptData`.
-  If Poseidon: the byte string R is chunked into 31-byte blocks,
-  each interpreted as a little-endian BN254 Fr field element (standard
-  for BN254 Poseidon implementations such as iden3/circomlibjs and
-  the Poseidon syscall in SIMD-0359). Domain separation uses a
-  capacity element of 1 (distinct from the nullifier domain). Two
-  implementations must agree on this encoding or roots diverge; this
-  is an open question if Poseidon is chosen.
+  If Poseidon: a byte-to-field-element encoding must be agreed before
+  this path can be implemented. Poseidon operates on field elements,
+  not byte strings; different chunking schemes produce different roots.
+  Specifying a canonical encoding for R -> [Fr] is a prerequisite open
+  question gating the Poseidon path.
   Private witness: MAX_DEPTH sibling hashes and direction bits
   connecting this leaf to `receipt_tree_root`.
 - `block_header_hash` — binds the proof to a specific block

--- a/proposals/0064-transaction-receipt.md
+++ b/proposals/0064-transaction-receipt.md
@@ -427,9 +427,9 @@ compatibility concerns.
 
 ---
 
-## Revival Notice — 2026-05-31
+## Update — 2026-05-31
 
-**New implementation champions:** Parad0x Labs / sls_0x  
+We built on top of this spec and are picking up the work. — Parad0x Labs / sls_0x  
 **Status change:** Stagnant → Active (revival)  
 **Contact:** github.com/Parad0x-Labs / github.com/Parad0x-Labs/dna-x402
 

--- a/proposals/0064-transaction-receipt.md
+++ b/proposals/0064-transaction-receipt.md
@@ -5,9 +5,10 @@ authors:
   - Anoushk Kharangate (Tinydancer)
   - Richard Patel (Jump)
   - Harsh Patel (Tinydancer)
+  - sls_0x (Parad0x Labs)
 category: Standard
 type: Core
-status: Stagnant
+status: Draft
 created: 2023-06-20
 feature: N/A
 ---
@@ -429,54 +430,73 @@ compatibility concerns.
 
 ## Update — 2026-05-31
 
-We built on top of this spec and are picking up the work. — Parad0x Labs / sls_0x  
-**Status change:** Stagnant → Active (revival)  
-**Contact:** github.com/Parad0x-Labs / github.com/Parad0x-Labs/dna-x402
+Picking this up. — sls_0x / Parad0x Labs (https://github.com/Parad0x-Labs/dna-x402)
 
-### Why we're reviving this
+### Why
 
-AI agents making micropayments via the x402 protocol need lightweight, trustless
-receipt verification. Today the only options are: trust an RPC, or run a full
-validator. SIMD-0064 provides a third path: a compact proof that a transaction
-was included in a specific block, verifiable by anyone holding the block header.
+We built x402 payment receipts for AI agents on Solana. The application layer
+is live on mainnet: `receipt_anchor` (`6HSRGivdYR5D7yTDy1TFMCM8h3LzXxRtKU1RA3RnCMRN`)
+anchors 32-byte receipt hashes in hourly Merkle buckets on-chain. The missing
+piece is block-level inclusion proof so downstream verifiers do not have to trust
+an RPC.
 
-We have an application-layer implementation already live on Solana mainnet:
+We also have `dark_bn254_gate` (`GCptvBYF8S6eVYoh15B7WAESc54FUHCpN1Ui6aHeQYZd`)
+live on mainnet — a Groth16 BN254 verifier using the native `alt_bn128_pairing`
+syscall at ~200k CU. This is the on-chain primitive for the ZK extension below.
 
-- **`receipt_anchor` program** (`6HSRGivdYR5D7yTDy1TFMCM8h3LzXxRtKU1RA3RnCMRN`):
-  accumulates 32-byte SHA-256 anchors into hourly-windowed `AnchorBucket` PDAs,
-  each holding a running Merkle root. This is the application layer that needs
-  SIMD-0064's block-level inclusion proof underneath it.
+### Proposed optional extension: Groth16 Merkle inclusion proof
 
-- **`dark_bn254_gate` program** (`GCptvBYF8S6eVYoh15B7WAESc54FUHCpN1Ui6aHeQYZd`):
-  a live Groth16 BN254 verifier using Solana's native `alt_bn128_pairing` syscall.
-  This is the cryptographic primitive for the ZK extension described below.
+Intent to specify — not a finished spec. Open questions are called out explicitly.
 
-- **DNA x402 repo**: https://github.com/Parad0x-Labs/dna-x402
+**Variable block size — fixed MAX_DEPTH:**
+Groth16 circuits are parameterised at ceremony time and cannot change after the
+fact. Solana block transaction counts vary widely, so the circuit must target a
+hardcoded maximum depth. Proposed: `MAX_DEPTH = 20` (up to 2^20 ≈ 1M
+transactions per block). Smaller blocks pad empty leaves with `H(0)`. One
+circuit, one ceremony, covers all valid block sizes within that bound. Blocks
+exceeding the depth limit fall back to the existing hash-chain proof variant.
 
-### Proposed extension: Groth16 Merkle inclusion proof variant
+**Hash function (open question — needs working group input):**
+The SIMD-0064 receipt tree uses SHA-256. SHA-256 inside a Groth16 circuit costs
+~27k constraints per hash. A ZK-friendly hash (e.g. Poseidon over BN254) is
+~100x cheaper but produces a different root that diverges from the existing
+SHA-256 tree — it cannot reuse that root directly. Two paths: (a) keep SHA-256,
+accept the higher constraint count, reuse the existing tree root; (b) add a
+parallel Poseidon commitment to the block header alongside the SHA-256 hash.
+The right choice depends on what validators can feasibly commit in the header.
+We are not deciding this here.
 
-We propose adding an optional ZK variant alongside the existing hash-chain proof:
+**Block-header commitment (requires validator input):**
+The circuit takes the receipt tree root as a public input. For a verifier to
+trust that root, it must appear in a committed block-header field that light
+clients can verify. SIMD-0064 already requires validators to build the receipt
+tree at block production time — this extension additionally requires the root
+to be included in the header. Specifying which field is out of our scope and a
+prerequisite before this extension can be deployed end-to-end.
 
-- **Circuit:** proves `leaf ∈ Merkle-tree(block_entries)` without revealing the leaf position
-- **Public inputs:** block header hash, transaction hash, tree root
-- **Proof system:** Groth16 over BN254 — matches Solana's existing `alt_bn128` syscalls
-- **On-chain verification:** ~200k CU via the native precompile (demonstrated in `dark_bn254_gate`)
-- **Use case:** privacy-preserving payment channels and agent-to-agent settlements where
-  position metadata leaks are unacceptable
+**Ceremony (separate from our existing circuits):**
+Our existing `null_proof` circuit has a 2-party ceremony; the transcript is at
+https://github.com/Parad0x-Labs/dna-x402/blob/main/evidence/zk/ceremony-v2.json.
+That ceremony is for a different circuit. The Merkle inclusion circuit does not
+exist yet and requires a separate ceremony. Two-party trust model: if either
+participant destroyed their toxic waste, the setup is sound. For a settlement
+use case we would run a larger public ceremony before deploying.
 
-### What we're committing to
+**Proposed public inputs:**
+- `receipt_tree_root` — root of the fixed-depth receipt tree (hash function TBD)
+- `tx_hash` — hash of the transaction receipt being proved
+- `block_header_hash` — binds the proof to a specific block
 
-1. Update this SIMD with the ZK variant as a formally specified extension
-2. Implement the Merkle inclusion circuit (Circom, 2-party ceremony already completed
-   for our existing circuits — see `evidence/zk/ceremony-v2.json`)
-3. Produce RFC-style test vectors against devnet blocks
-4. Coordinate with Firedancer/Agave teams on the proof interface spec
+**What we are not touching:**
+Agave or Firedancer internals. The validator side needs to (1) build the
+fixed-depth tree at block production and (2) commit the root to a header field.
+We own the on-chain verifier and client SDK.
 
-We are **not** proposing changes to Agave or Firedancer internals. Our scope is
-on-chain verification and the application SDK — we will define the proof interface
-that validators would need to produce, not implement the validator side.
+### What we are committing to
 
-### Connection to grant application
-
-We have an open Solana Foundation grant application ($65k — external audit + ZK
-sprint + Squads multisig). This SIMD revival is part of that grant scope.
+1. Resolve hash function choice with the working group (SHA-256 vs Poseidon)
+2. Formalise `MAX_DEPTH` and the empty-leaf padding rule
+3. Define which block-header field carries the receipt tree root (needs validator input)
+4. Implement the fixed-depth Merkle inclusion circuit (Circom)
+5. Run a public multi-party ceremony for the new circuit
+6. Produce test vectors against devnet blocks

--- a/proposals/0064-transaction-receipt.md
+++ b/proposals/0064-transaction-receipt.md
@@ -447,84 +447,32 @@ We also have `dark_bn254_gate`
 Groth16 BN254 verifier using the native `alt_bn128_pairing` syscall at
 ~200k CU. This is the on-chain primitive for the ZK extension below.
 
-### Proposed optional extension: Groth16 Merkle inclusion proof
+### Planned extension: ZK inclusion proof (separate discussion)
 
-Intent to specify — not a finished spec. Open questions called out below.
+Beyond the hash-chain proof above, we intend to propose an optional
+Groth16/BN254 Merkle inclusion proof: prove a transaction's inclusion
+without revealing its position in the block. The on-chain verifier
+primitive already exists — `dark_bn254_gate` is live on mainnet and runs
+the BN254 pairing via `alt_bn128_pairing` at ~200k CU.
 
-**Variable block size — fixed MAX_DEPTH:**
-Groth16 circuits are parameterised at ceremony time and cannot change after the
-fact. Solana block transaction counts vary widely, so the circuit must target a
-hardcoded maximum depth. Proposed: `MAX_DEPTH = 20` (up to 2^20 ≈ 1M
-transactions per block). Smaller blocks pad empty leaves with `H(0)` where
-`H(0)` is defined as the hash function applied to a 32-byte all-zero input.
-This resolves deterministically: `SHA-256(0x00...00)` or
-`Poseidon(0, 0)` depending on the hash function chosen above. All
-implementations must agree on this value or Merkle roots will diverge. One
-circuit, one ceremony, covers all valid block sizes within that bound. Blocks
-exceeding the depth limit fall back to the SIMD-0064 hash-chain inclusion proof
-(Sections 4–6 of this document), which has no depth constraint.
+This is **not specified in this PR.** It depends on design choices that
+belong in a dedicated SIMD discussion, not a final-spec change. The open
+questions we have identified so far:
 
-**Hash function and tree compatibility:**
-The existing SIMD-0064 receipt tree pads non-power-of-2 leaf counts by
-duplicating the last real leaf (not with H(0)). A fixed-depth ZK tree
-using H(0) padding therefore produces a different root for virtually all
-blocks. Reusing the existing SIMD-0064 tree root in the ZK circuit is not
-feasible without changing the SIMD-0064 tree construction, which is a
-breaking change.
+- **Fixed vs. variable depth.** Groth16 constraint systems are fixed at
+  ceremony time, but block transaction counts vary widely. A single
+  circuit needs a fixed maximum depth with a defined padding and overflow
+  rule.
+- **Hash function.** SHA-256 matches the existing tree but is expensive in
+  a circuit (~27k constraints/hash). A ZK-friendly hash such as Poseidon is
+  far cheaper but needs a canonical byte-to-field encoding and a separate
+  tree, since its padding differs from the existing leaf-duplication tree.
+- **Header commitment.** The tree root must be committed in a block-header
+  field for light clients to trust it. Which field is validator-side and
+  needs Anza / Firedancer input.
+- **Trusted setup.** A new circuit needs its own multi-party ceremony; our
+  existing ceremonies are for different circuits.
 
-The ZK extension therefore requires a **separate, dedicated receipt tree**
-committed in the block header alongside the existing one. The dedicated
-tree uses fixed-depth H(0) padding (defined above) and a TBD hash
-function. Inside the Groth16 circuit, SHA-256 costs ~27k constraints per
-hash; Poseidon over BN254 is ~100x cheaper. Either works if the header
-commits to the same root. The hash function choice is a question for the
-working group.
-
-**Block-header commitment (requires validator input):**
-The circuit takes the receipt tree root as a public input. For a verifier to
-trust that root, it must appear in a committed block-header field that light
-clients can verify. SIMD-0064 already requires validators to build the receipt
-tree at block production time — this extension additionally requires the root
-to be included in the header. Specifying which field is out of our scope and a
-prerequisite before this extension can be deployed end-to-end.
-
-**Ceremony (separate from our existing circuits):**
-Our existing `null_proof` circuit has a 2-party ceremony; the transcript is at
-https://github.com/Parad0x-Labs/dna-x402/blob/main/evidence/zk/ceremony-v2.json.
-That ceremony is for a different circuit. The Merkle inclusion circuit does not
-exist yet and requires a separate ceremony. Two-party trust model: if either
-participant destroyed their toxic waste, the setup is sound. For a settlement
-use case we would run a larger public ceremony before deploying.
-
-**Proposed public inputs:**
-
-- `receipt_tree_root` — root of the fixed-depth receipt tree
-  (hash function TBD, see above)
-- `tx_hash` — the leaf value of the dedicated ZK receipt tree.
-  If SHA-256: `sha256(0x00 || R)` matching the SIMD-0064 leaf exactly,
-  where R is the serialised `TransactionReceiptData`.
-  If Poseidon: a byte-to-field-element encoding must be agreed before
-  this path can be implemented. Poseidon operates on field elements,
-  not byte strings; different chunking schemes produce different roots.
-  Specifying a canonical encoding for R -> [Fr] is a prerequisite open
-  question gating the Poseidon path.
-  Private witness: MAX_DEPTH sibling hashes and direction bits
-  connecting this leaf to `receipt_tree_root`.
-- `block_header_hash` — binds the proof to a specific block
-
-**Validator changes required:**
-This extension requires validators to build a second, fixed-depth receipt
-tree at block production and commit its root to a block-header field.
-That is a validator-side change. We are not implementing it — we are
-defining the spec so Agave and Firedancer teams can decide if and how to
-adopt it. We own the on-chain verifier and client SDK.
-
-### What we are committing to
-
-1. Resolve hash function choice with the working group (SHA-256 vs Poseidon)
-2. Formalise `MAX_DEPTH` and the empty-leaf padding rule
-3. Define which block-header field carries the receipt tree root
-   (needs validator input)
-4. Implement the fixed-depth Merkle inclusion circuit (Circom)
-5. Run a public multi-party ceremony for the new circuit
-6. Produce test vectors against devnet blocks
+We will bring this as a separate discussion with a complete design once
+those are resolved, per the SIMD process. The working sketch, our existing
+circuits, and ceremony transcripts live in the DNA x402 repo linked above.


### PR DESCRIPTION
## What this is

Original authors (Anoushk Kharangate / Tinydancer, Richard Patel / Jump Crypto) did the spec work. They've been inactive since October 2024. We built on top of this and are picking up where they left off.

— Parad0x Labs / sls_0x (github.com/Parad0x-Labs/dna-x402)

## Why we care

We're building x402 payment receipts for AI agents on Solana. We have the application layer running on mainnet already:

- `receipt_anchor` (`6HSRGivdYR5D7yTDy1TFMCM8h3LzXxRtKU1RA3RnCMRN`) — anchors 32-byte receipt hashes on-chain in hourly Merkle buckets. Already used to anchor 86,400 agent payment receipts in one tx ($0.001 total).
- `dark_bn254_gate` (`GCptvBYF8S6eVYoh15B7WAESc54FUHCpN1Ui6aHeQYZd`) — live Groth16 BN254 verifier on mainnet, built on the alt_bn128 syscalls.

The missing piece is block-level inclusion proof so downstream verifiers don't have to trust an RPC.

## What we're adding

An optional ZK variant using Groth16 over BN254:
- proves `tx ∈ block` without revealing position
- verifiable on-chain with the existing alt_bn128 syscalls (~200k CU)
- useful when position metadata leaks are a problem (private payment channels etc)

## What we're committing to

- spec the ZK variant properly in the SIMD text
- implement the Merkle inclusion circuit (Circom — we have ceremony infrastructure already)
- write test vectors against devnet blocks
- spec the proof interface validators would need to produce (not touching Agave/Firedancer internals)

## Links
- DNA x402: https://github.com/Parad0x-Labs/dna-x402
- receipt_anchor on-chain: https://explorer.solana.com/address/6HSRGivdYR5D7yTDy1TFMCM8h3LzXxRtKU1RA3RnCMRN
- Groth16 gate on-chain: https://explorer.solana.com/address/GCptvBYF8S6eVYoh15B7WAESc54FUHCpN1Ui6aHeQYZd