### PR TITLE
Revival: SIMD-0302 BN254 G2 syscalls — implementation champions

### DIFF
--- a/proposals/0302-bn254-g2-syscalls.md
+++ b/proposals/0302-bn254-g2-syscalls.md
@@ -3,9 +3,10 @@ simd: '0302'
 title: BN254 G2 Arithmetic Syscalls
 authors:
   - Blockiosaurus (Metaplex Foundation)
+  - sls_0x (Parad0x Labs)
 category: Standard
 type: Core
-status: Review
+status: Draft
 created: 2025-06-12
 feature:
 supersedes:
@@ -15,30 +16,32 @@ extends:
 
 ## Summary
 
-Extend the existing `sol_alt_bn128_group_op` syscall to support native G2 curve
-point arithmetic (addition, subtraction, and scalar multiplication) on the BN254
-curve.
+Extend the existing `sol_alt_bn128_group_op` syscall to support native G2
+curve point arithmetic (addition, subtraction, and scalar multiplication)
+on the BN254 curve.
 
 ## Motivation
 
-Solana today provides syscalls for Alt‑BN128 G1 group operations
-(`ALT_BN128_ADD`, `ALT_BN128_SUB`, `ALT_BN128_MUL`) and for pairing checks, as
-well as compression/decompression for G2 points. However, there is no direct
-support for arithmetic on G2 points themselves, as they were not included in the
-Ethereum Precompile on which the syscalls were based.
+Solana today provides syscalls for Alt-BN128 G1 group operations
+(`ALT_BN128_ADD`, `ALT_BN128_SUB`, `ALT_BN128_MUL`) and for pairing
+checks, as well as compression/decompression for G2 points. However,
+there is no direct support for arithmetic on G2 points themselves, as
+they were not included in the Ethereum Precompile on which the syscalls
+were based.
 
 Adding native G2 syscalls will enable:
 
-- Batch Groth16 verification: Multiple proofs could be aggregated into single
-verification calls
-- KZG polynomial commitments: Enable efficient multi-point opening proofs and
-batch verification
+- Batch Groth16 verification: Multiple proofs could be aggregated into
+  single verification calls
+- KZG polynomial commitments: Enable efficient multi-point opening
+  proofs and batch verification
 - Other more advanced ZK systems for batch or direct verification
 
 ## New Terminology
 
-- **G2 point**: A point on the twist subgroup of BN254, represented as two Fq₂
-elements (each element is a pair of 32‑byte field coefficients).
+- **G2 point**: A point on the twist subgroup of BN254, represented as
+  two Fq2 elements (each element is a pair of 32-byte field
+  coefficients).
 
 ## Detailed Design
 
@@ -46,24 +49,27 @@ elements (each element is a pair of 32‑byte field coefficients).
 
 ```rust
 // Field and point sizes
-pub const ALT_BN128_FIELD_SIZE:       u64 = 32;
+pub const ALT_BN128_FIELD_SIZE:    u64 = 32;
     // bytes per Fq element
-pub const ALT_BN128_G2_POINT_SIZE:    u64 = ALT_BN128_FIELD_SIZE * 4;
-    // x=(x0,x1), y=(y0,y1) each 32‑byte
+pub const ALT_BN128_G2_POINT_SIZE: u64 = ALT_BN128_FIELD_SIZE * 4;
+    // x=(x0,x1), y=(y0,y1) each 32-byte
 
 // G2 addition/subtraction
-pub const ALT_BN128_G2_ADDITION_INPUT_LEN:   u64 = ALT_BN128_G2_POINT_SIZE * 2;
-    // 256
-pub const ALT_BN128_G2_ADDITION_OUTPUT_LEN:  u64 = ALT_BN128_G2_POINT_SIZE;
-    // 128
+pub const ALT_BN128_G2_ADDITION_INPUT_LEN:   u64 =
+    ALT_BN128_G2_POINT_SIZE * 2; // 256
+pub const ALT_BN128_G2_ADDITION_OUTPUT_LEN:  u64 =
+    ALT_BN128_G2_POINT_SIZE;     // 128
 
 // G2 scalar multiplication
-pub const ALT_BN128_G2_MULTIPLICATION_INPUT_LEN:  u64 = ALT_BN128_G2_POINT_SIZE
-    + ALT_BN128_FIELD_SIZE; // 160
-pub const ALT_BN128_G2_MULTIPLICATION_OUTPUT_LEN: u64 = ALT_BN128_G2_POINT_SIZE;
-    // 128
+pub const ALT_BN128_G2_MULTIPLICATION_INPUT_LEN:  u64 =
+    ALT_BN128_G2_POINT_SIZE + ALT_BN128_FIELD_SIZE; // 160
+pub const ALT_BN128_G2_MULTIPLICATION_OUTPUT_LEN: u64 =
+    ALT_BN128_G2_POINT_SIZE; // 128
+```
 
 ### New Opcodes
+
+```rust
 pub const ALT_BN128_G2_ADD: u64 = 4;
 pub const ALT_BN128_G2_SUB: u64 = 5;
 pub const ALT_BN128_G2_MUL: u64 = 6;
@@ -71,48 +77,99 @@ pub const ALT_BN128_G2_MUL: u64 = 6;
 
 ### Endianness
 
-Additional G2 operation support for little endian formats should also be
-included use the little-endian encoding conventions as specified in
-[SIMD-0284](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0284-alt-bn128-little-endian.md),
-consistent with existing BN128 syscalls.
+Additional G2 operation support for little-endian formats should also
+be included, using the little-endian encoding conventions as specified
+in [SIMD-0284], consistent with existing BN128 syscalls.
+
+[SIMD-0284]: https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0284-alt-bn128-little-endian.md
 
 ### Validation and Subgroup Checks
 
-The validation requirements for the new G2 operations are defined as follows to
-balance safety and compute cost, consistent with the approach for BLS12-381:
+The validation requirements for the new G2 operations are defined as
+follows to balance safety and compute cost, consistent with the approach
+for BLS12-381:
 
-1. _G2 Addition (`ALT_BN128_G2_ADD`) and Subtraction (`ALT_BN128_G2_SUB`)_:
-   - Input points MUST be validated to ensure they are on the curve (satisfy
-     the G2 curve equation).
-   - The _subgroup check is skipped_. The addition formulas are valid for
-     any point on the curve (including those not in the prime-order subgroup).
-     Skipping this costly check allows for cheaper accumulation of points.
+1. _G2 Addition (`ALT_BN128_G2_ADD`) and Subtraction
+   (`ALT_BN128_G2_SUB`)_:
+   - Input points MUST be validated to ensure they are on the curve
+     (satisfy the G2 curve equation).
+   - The _subgroup check is skipped_. The addition formulas are valid
+     for any point on the curve (including those not in the prime-order
+     subgroup). Skipping this costly check allows for cheaper
+     accumulation of points.
 
 2. _G2 Scalar Multiplication (`ALT_BN128_G2_MUL`)_:
-   - Input points MUST undergo _full validation_, including the field check,
-     curve equation check, and the _subgroup check_.
+   - Input points MUST undergo _full validation_, including the field
+     check, curve equation check, and the _subgroup check_.
    - Enforcing the subgroup check is required to safely support faster
      endomorphism-based scalar multiplication algorithms.
 
-_Note on G1_: For the existing G1 operations, the BN254 (Alt-BN128) curve has
-a cofactor of 1. This means that every point satisfying the curve equation is
-automatically in the prime-order subgroup. Therefore, no separate subgroup
-check is needed for G1 as the on-curve check is sufficient.
+_Note on G1_: For the existing G1 operations, the BN254 (Alt-BN128)
+curve has a cofactor of 1. This means that every point satisfying the
+curve equation is automatically in the prime-order subgroup. Therefore,
+no separate subgroup check is needed for G1 as the on-curve check is
+sufficient.
 
 ## Alternatives Considered
 
-- Separate G2‑only syscall entrypoint rather than extending sol_alt_bn128_group_op.
-- Drawback: Increases API surface, doubles maintenance.
-- Library‑level intrinsics (BPF C/Rust) for G2 math as fallback.
-- Drawback: Slower, higher compute cost than native syscalls.
+- Separate G2-only syscall entrypoint rather than extending
+  `sol_alt_bn128_group_op`.
+  - Drawback: Increases API surface, doubles maintenance.
+- Library-level intrinsics (BPF C/Rust) for G2 math as fallback.
+  - Drawback: Slower, higher compute cost than native syscalls.
 
 ## Impact
 
-- Native G2 ops reduce compute units by approximately 10×–20× compared to
-pure‑BPF implementations.
-- Enables newer and more advanced ZK verification methods as well as batch proof
-verification
+- Native G2 ops reduce compute units by approximately 10x-20x compared
+  to pure-BPF implementations.
+- Enables newer and more advanced ZK verification methods as well as
+  batch proof verification.
 
 ## Security Considerations
 
-None
+None.
+
+---
+
+## Revival note (2026-06-01)
+
+Revived by sls_0x (Parad0x Labs) as implementation champions.
+
+### Why we care
+
+Parad0x Labs ships the `dark_bn254_gate` program on Solana mainnet
+(program ID: `GCptvBYF8S6eVYoh15B7WAESc54FUHCpN1Ui6aHeQYZd`). It uses
+the existing G1 syscalls (`ALT_BN128_ADD`, `ALT_BN128_MUL`,
+`ALT_BN128_PAIRING`) to verify BN254-based ZK proofs on-chain.
+
+Running a complete Groth16 verifier requires arithmetic on both G1 and
+G2 points. Specifically, the verification key for a Groth16 proof
+includes `beta_g2` and `gamma_g2` — verification key points that live
+in G2. The final pairing check computes:
+
+```
+e(A, B) * e(alpha_g1, neg(beta_g2)) * e(L, neg(gamma_g2)) == 1
+```
+
+`alpha_g1` and `L` are G1 points and can be computed with existing
+syscalls. `beta_g2` and `gamma_g2` are G2 points. Without native G2
+arithmetic, an on-chain Groth16 verifier must hardcode those constants
+at deploy time and cannot support variable verification keys. The same
+constraint applies to KZG-based proof systems (PLONK, Marlin) that use
+G2 commitments.
+
+### What we commit to
+
+1. **Reference implementation** — We will write a reference BPF program
+   exercising `ALT_BN128_G2_ADD`, `ALT_BN128_G2_SUB`, and
+   `ALT_BN128_G2_MUL` against known test vectors from the EIP-2537 and
+   EIP-196/197 test suites.
+2. **Test vectors** — We will provide a comprehensive set of test
+   vectors (valid points, infinity, out-of-subgroup inputs) covering
+   both big-endian and little-endian encodings per SIMD-0284.
+3. **Anza coordination** — We will open tracking issues in
+   `anza-xyz/agave` to align on compute-unit budgets and syscall
+   activation gating once the spec is accepted.
+4. **Compute-unit benchmarks** — We will benchmark the proposed
+   opcodes against our existing mainnet program to confirm the
+   10x-20x CU reduction claim in the Impact section above.

--- a/proposals/0302-bn254-g2-syscalls.md
+++ b/proposals/0302-bn254-g2-syscalls.md
@@ -73,13 +73,22 @@ pub const ALT_BN128_G2_MULTIPLICATION_OUTPUT_LEN: u64 =
 pub const ALT_BN128_G2_ADD: u64 = 4;
 pub const ALT_BN128_G2_SUB: u64 = 5;
 pub const ALT_BN128_G2_MUL: u64 = 6;
+
+// Little-endian variants (SIMD-0284 convention: BE opcode + 128)
+pub const ALT_BN128_G2_ADD_LE: u64 = 132; // 4 + 128
+pub const ALT_BN128_G2_SUB_LE: u64 = 133; // 5 + 128
+pub const ALT_BN128_G2_MUL_LE: u64 = 134; // 6 + 128
 ```
 
 ### Endianness
 
-Additional G2 operation support for little-endian formats should also
-be included, using the little-endian encoding conventions as specified
-in [SIMD-0284], consistent with existing BN128 syscalls.
+Additional G2 operation support for little-endian formats is included,
+using the little-endian encoding conventions from [SIMD-0284]. The LE
+opcode values follow the same +128 convention as existing G1 LE ops:
+`ALT_BN128_G2_ADD_LE = 132`, `ALT_BN128_G2_SUB_LE = 133`,
+`ALT_BN128_G2_MUL_LE = 134`. This is consistent with
+`ALT_BN128_ADD_LE = 128`, `ALT_BN128_SUB_LE = 129`,
+`ALT_BN128_MUL_LE = 130` already specified in [SIMD-0284].
 
 [SIMD-0284]: https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0284-alt-bn128-little-endian.md
 
@@ -162,8 +171,11 @@ G2 commitments.
 
 1. **Reference implementation** — We will write a reference BPF program
    exercising `ALT_BN128_G2_ADD`, `ALT_BN128_G2_SUB`, and
-   `ALT_BN128_G2_MUL` against known test vectors from the EIP-2537 and
-   EIP-196/197 test suites.
+   `ALT_BN128_G2_MUL` against known test vectors. BN254 G2 test vectors
+   come from EIP-196/197 (not EIP-2537, which covers BLS12-381).
+   Additional vectors from the Ethereum `bn256` test suite
+   (https://github.com/ethereum/tests/tree/develop/GeneralStateTests)
+   will be used to validate the implementation.
 2. **Test vectors** — We will provide a comprehensive set of test
    vectors (valid points, infinity, out-of-subgroup inputs) covering
    both big-endian and little-endian encodings per SIMD-0284.

--- a/proposals/0302-bn254-g2-syscalls.md
+++ b/proposals/0302-bn254-g2-syscalls.md
@@ -155,11 +155,12 @@ includes `beta_g2` and `gamma_g2` — verification key points that live
 in G2. The final pairing check computes:
 
 ```
-e(A, B) * e(alpha_g1, neg(beta_g2)) * e(L, neg(gamma_g2)) == 1
+e(A, B) * e(alpha_g1, neg(beta_g2)) * e(L, neg(gamma_g2)) * e(C, neg(delta_g2)) == 1
 ```
 
-`alpha_g1` and `L` are G1 points and can be computed with existing
-syscalls. `beta_g2` and `gamma_g2` are G2 points. Without native G2
+`A`, `C`, `alpha_g1`, and `L` (the linear combination of IC points)
+are G1 and use existing syscalls. `beta_g2`, `gamma_g2`, `delta_g2`
+are all G2 points. Without native G2
 arithmetic, an on-chain Groth16 verifier must hardcode those constants
 at deploy time and cannot support variable verification keys. The same
 constraint applies to KZG-based proof systems (PLONK, Marlin) that use
@@ -168,12 +169,13 @@ G2 commitments.
 ### What we are doing
 
 1. **Reference implementation** — BPF program exercising
-   `ALT_BN128_G2_ADD`, `ALT_BN128_G2_SUB`, and
-   `ALT_BN128_G2_MUL` against known test vectors. BN254 G2 test vectors
-   come from EIP-196/197 (not EIP-2537, which covers BLS12-381).
-   Additional vectors from the Ethereum `bn256` test suite
-   (https://github.com/ethereum/tests/tree/develop/GeneralStateTests)
-   will be used to validate the implementation.
+   `ALT_BN128_G2_ADD`, `ALT_BN128_G2_SUB`, and `ALT_BN128_G2_MUL`.
+   Test vectors from the `go-ethereum` bn256 library
+   (https://github.com/ethereum/go-ethereum/tree/master/crypto/bn256)
+   and the Ethereum consensus test suite
+   (https://github.com/ethereum/tests). Note: EIP-196/197 only define
+   G1 operations; G2 test vectors come from the go-ethereum
+   implementation directly.
 2. **Test vectors** — We will provide a comprehensive set of test
    vectors (valid points, infinity, out-of-subgroup inputs) covering
    both big-endian and little-endian encodings per SIMD-0284.

--- a/proposals/0302-bn254-g2-syscalls.md
+++ b/proposals/0302-bn254-g2-syscalls.md
@@ -90,7 +90,9 @@ opcode values follow the same +128 convention as existing G1 LE ops:
 `ALT_BN128_ADD_LE = 128`, `ALT_BN128_SUB_LE = 129`,
 `ALT_BN128_MUL_LE = 130` already specified in [SIMD-0284].
 
+<!-- markdownlint-disable MD013 -->
 [SIMD-0284]: https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0284-alt-bn128-little-endian.md
+<!-- markdownlint-enable MD013 -->
 
 ### Validation and Subgroup Checks
 

--- a/proposals/0302-bn254-g2-syscalls.md
+++ b/proposals/0302-bn254-g2-syscalls.md
@@ -140,16 +140,14 @@ None.
 
 ---
 
-## Revival note (2026-06-01)
+## Update (2026-06-01)
 
-Revived by sls_0x (Parad0x Labs) as implementation champions.
+Picking this up. — sls_0x (Parad0x Labs)
 
-### Why we care
-
-Parad0x Labs ships the `dark_bn254_gate` program on Solana mainnet
-(program ID: `GCptvBYF8S6eVYoh15B7WAESc54FUHCpN1Ui6aHeQYZd`). It uses
-the existing G1 syscalls (`ALT_BN128_ADD`, `ALT_BN128_MUL`,
-`ALT_BN128_PAIRING`) to verify BN254-based ZK proofs on-chain.
+We run `dark_bn254_gate` on Solana mainnet
+(`GCptvBYF8S6eVYoh15B7WAESc54FUHCpN1Ui6aHeQYZd`). It uses the existing
+G1 syscalls (`ALT_BN128_ADD`, `ALT_BN128_MUL`, `ALT_BN128_PAIRING`) to
+verify BN254-based ZK proofs on-chain.
 
 Running a complete Groth16 verifier requires arithmetic on both G1 and
 G2 points. Specifically, the verification key for a Groth16 proof
@@ -167,10 +165,10 @@ at deploy time and cannot support variable verification keys. The same
 constraint applies to KZG-based proof systems (PLONK, Marlin) that use
 G2 commitments.
 
-### What we commit to
+### What we are doing
 
-1. **Reference implementation** — We will write a reference BPF program
-   exercising `ALT_BN128_G2_ADD`, `ALT_BN128_G2_SUB`, and
+1. **Reference implementation** — BPF program exercising
+   `ALT_BN128_G2_ADD`, `ALT_BN128_G2_SUB`, and
    `ALT_BN128_G2_MUL` against known test vectors. BN254 G2 test vectors
    come from EIP-196/197 (not EIP-2537, which covers BLS12-381).
    Additional vectors from the Ethereum `bn256` test suite

--- a/proposals/0302-bn254-g2-syscalls.md
+++ b/proposals/0302-bn254-g2-syscalls.md
@@ -155,7 +155,8 @@ includes `beta_g2` and `gamma_g2` — verification key points that live
 in G2. The final pairing check computes:
 
 ```
-e(A, B) * e(alpha_g1, neg(beta_g2)) * e(L, neg(gamma_g2)) * e(C, neg(delta_g2)) == 1
+e(A, B) * e(alpha_g1, neg(beta_g2))
+         * e(L, neg(gamma_g2)) * e(C, neg(delta_g2)) == 1
 ```
 
 `A`, `C`, `alpha_g1`, and `L` (the linear combination of IC points)

--- a/proposals/0302-bn254-g2-syscalls.md
+++ b/proposals/0302-bn254-g2-syscalls.md
@@ -11,7 +11,7 @@ created: 2025-06-12
 feature:
 supersedes:
 superseded-by:
-extends:
+extends: 0284-alt-bn128-little-endian.md
 ---
 
 ## Summary
@@ -138,7 +138,16 @@ sufficient.
 
 ## Security Considerations
 
-None.
+**Subgroup membership for G2 ADD and SUB:** The validation rules
+intentionally skip the subgroup check for `ALT_BN128_G2_ADD` and
+`ALT_BN128_G2_SUB` (consistent with BLS12-381 SIMD-0388). These
+operations are valid for any curve point, including small-subgroup
+points. Callers who pipeline G2 ADD/SUB outputs directly into a
+pairing without an intervening scalar multiplication **must** ensure
+the accumulated point is in the prime-order subgroup before the
+pairing call, or the pairing result may be incorrect. The subgroup
+check is enforced for `ALT_BN128_G2_MUL`, making it the safe entry
+point for pairing inputs derived from untrusted data.
 
 ---
 


### PR DESCRIPTION
Picking up SIMD-0302. Original author (Blockiosaurus/Metaplex) has been
inactive. We need G2 ops for our Groth16 verifier work.

Changes:
- Status: `Review` → `Draft`
- Add `sls_0x (Parad0x Labs)` as co-author
- Fix broken code fence: `### New Opcodes` heading was inside the
  `### New Constants` fence block
- Reflow lines to ≤80 chars
- Add LE opcode constants: 132/133/134 (were missing, spec gap)
- Fix wrong test vector citation: EIP-2537 is BLS12-381, not BN254
- Add context for why G2 is needed

## Why G2 matters

`dark_bn254_gate` (`GCptvBYF8S6eVYoh15B7WAESc54FUHCpN1Ui6aHeQYZd`) is
a live Groth16 verifier on Solana mainnet using the existing G1 syscalls.

The pairing check in Groth16 is:
`e(A, B) * e(-alpha, beta) * e(-vk_x, gamma) * e(-C, delta) = 1`

`beta`, `gamma`, `delta` are G2 points. Right now those are hardcoded
in the verifying key. With G2 arithmetic on-chain, verifiers can do
`scalar * G2_generator` dynamically — which is needed for PLONK,
BLS aggregation, and more general ZK gadgets.

## What we commit to

1. Reference BPF program using the new G2 opcodes
2. Test vectors from EIP-196/197 and the Ethereum bn256 test suite
3. CU benchmarks against existing G1 opcode costs
4. Tracking issue in anza-xyz/agave once spec is accepted

## Links

- Live mainnet program: https://explorer.solana.com/address/GCptvBYF8S6eVYoh15B7WAESc54FUHCpN1Ui6aHeQYZd
- Repo: https://github.com/Parad0x-Labs/dna-x402