### PR TITLE
Remove mentions of SIMD-0161

### DIFF
--- a/proposals/0166-dynamic-stack-frames.md
+++ b/proposals/0166-dynamic-stack-frames.md
@@ -131,8 +131,8 @@ retrieving the caller’s frame pointer address to access those parameters.
 
 ### Identification of programs
 
-As per the description in SIMD-0161, programs compiled with dynamic stack 
-frames must contain the `0x01` flag on their ELF header `e_flags` field.
+Programs compiled with dynamic stack frames must indicate the SBPF version 
+`0x01` or higher in their ELF header `e_flags` field.
 
 ## Impact
 

--- a/proposals/0173-sbpf-instruction-encoding-improvements.md
+++ b/proposals/0173-sbpf-instruction-encoding-improvements.md
@@ -8,7 +8,6 @@ type: Core
 status: Review
 created: 2024-09-05
 feature: F6UVKh1ujTEFK3en2SyAL3cdVnqko1FVEXWhmdLRu6WP
-extends: SIMD-0161
 ---
 
 ## Summary
@@ -62,7 +61,7 @@ None.
 ## Detailed Design
 
 The following must go into effect if and only if a program indicates the
-SBPF-version v2 or higher in its program header (see SIMD-0161). Some now
+SBPF-version v2 or higher in its program header. Some now
 unreachable verification and execution checks around `LDDW` can be safely
 removed (see motivation).
 

--- a/proposals/0174-sbpf-arithmetics-improvements.md
+++ b/proposals/0174-sbpf-arithmetics-improvements.md
@@ -8,7 +8,6 @@ type: Core
 status: Review
 created: 2024-09-06
 feature: F6UVKh1ujTEFK3en2SyAL3cdVnqko1FVEXWhmdLRu6WP
-extends: SIMD-0161
 ---
 
 ## Summary
@@ -49,7 +48,7 @@ None.
 ## Detailed Design
 
 The following must go into effect if and only if a program indicates the
-SBPF-version (v2) or higher in its program header (see SIMD-0161).
+SBPF-version (v2) or higher in its program header.
 
 ### Changes to the Bytecode Verifier
 

--- a/proposals/0178-static-syscalls.md
+++ b/proposals/0178-static-syscalls.md
@@ -45,8 +45,7 @@ None.
 ## Detailed Design
 
 The following must go into effect if and only if a program indicates the SBPF 
-version `0x03` or higher in its ELF header e_flags field, according to the 
-specification of SIMD-0161.
+version `0x03` or higher in its ELF header e_flags field.
 
 ### Static syscall instruction
 

--- a/proposals/0189-sbpf-stricter-elf-headers.md
+++ b/proposals/0189-sbpf-stricter-elf-headers.md
@@ -35,7 +35,7 @@ None.
 ## Detailed Design
 
 The following must go into effect if and only if a program indicates the
-SBPF-version v3 or higher in its program header (see SIMD-0161).
+SBPF-version v3 or higher in its program header.
 
 ### File header
 
@@ -55,7 +55,8 @@ otherwise `ElfParserError::OutOfBounds` must be thrown.
 - `e_entry` must be within the bounds of the second program header
 - `e_phoff` must be `size_of::<Elf64Ehdr>()` (64 bytes)
 - `e_shoff` is not checked
-- `e_flags` see SIMD-0161
+- `e_flags` must be the SBPF version (v3 or higher), meaning a value of 
+  `0x0003` is SBPFv3, `0x0004` is SBPFv4, etc.
 - `e_ehsize` must be `size_of::<Elf64Ehdr>()` (64 bytes)
 - `e_phnum` must be greater than or equal `0x0001`
 - `e_phoff + e_phnum * size_of::<Elf64Phdr>()` must be

--- a/proposals/0500-disable-deployment-of-sbpf-v0-v1-v2.md
+++ b/proposals/0500-disable-deployment-of-sbpf-v0-v1-v2.md
@@ -8,7 +8,6 @@ type: Core
 status: Idea
 created: 2026-03-17
 feature: TBD
-supersedes: 0161
 ---
 
 ## Summary


### PR DESCRIPTION
[SIMD-0161](https://github.com/solana-foundation/solana-improvement-documents/pull/161) was proposed but later closed. Subsequent SIMDs still refer to it; this commit removes all such mentions.

To my knowledge, given that SIMD-0161 no longer exists, there are no document describing the repurposing of the ELF header's `e_flags` field to encode the SBPF version. Hence, I opted to simply remove the references to SIMD-0161.