### PR TITLE
Clarify SIMD-0392 delegation adjustment timing

### DIFF
--- a/proposals/0392-rent-increase-adaptations.md
+++ b/proposals/0392-rent-increase-adaptations.md
@@ -193,8 +193,8 @@ section for more details.
 
 ### Rent-Adjusted Stake Delegations
 
-During the epoch rewards calculation phase, a stake's updated delegation MUST be
-calculated with the following formula:
+During the epoch rewards distribution phase, a stake's updated delegation MUST
+be adjusted with the following formula:
 
 ```
 post_delegation = min(
@@ -209,7 +209,7 @@ Where:
 - `pre_delegation`: the account's pre-reward delegated lamport amount
 - `stake_rewards`: the account's calculated stake reward lamport amount for the
   past epoch
-- `balance`: the account's pre-reward balance, in lamports
+- `balance`: the account's balance at distribution time, in lamports
 - `rent_exempt_reserve`: the minimum lamport balance required for the stake
   account (more information below)
 


### PR DESCRIPTION
#### Problem

During partitioned epoch rewards distribution, although it isn't possible to invoke the stake program to modify stakes, it is possible to credit lamports to stake accounts.

The current stake adjustment logic in SIMD-0392 performs the adjustment at calculation time, but it is possible for a stake account to be credited lamports prior to distribution, potentially removing any need to adjust the stake delegation.

#### Summary of changes

Update SIMD-0392 to specify that adjustment happens at distribution time, and not at calculation time.