### PR TITLE
SIMD-0568: Deprecate Precompiles

### DIFF
--- a/proposals/0568-deprecate-precompiles.md
+++ b/proposals/0568-deprecate-precompiles.md
@@ -17,7 +17,7 @@ Remove support for the secp256k1, secp256r1 and ed25519 precompiles.
 ## Motivation
 
 Precompiles are rigid, require special handling in validator implementations
-and their cross instruction referencing (in ed25519) is hacky.
+and their inter-instruction data referencing is hacky.
 
 ## Dependencies
 
@@ -60,10 +60,9 @@ These changes are limited to the program runtime component
 
 ### Migrating them to core programs on-chain
 
-The ed25519 one requires top-level instruction introspection, which is not
-available to programs on-chain without the Instructions sysvar. Thus it would
-require either breaking changes to the precompile or adding features to the
-SVM:
+Precompiles can use top-level instruction introspection, which is not available
+to programs on-chain without the Instructions sysvar. Thus it would require
+either breaking changes to the precompile or adding features to the SVM:
 
 - Require users to pass in all bytes to verify in the precompile instruction,
 forbidding cross referencing other instructions.
@@ -110,18 +109,23 @@ Breaking change: All precompiles will become unavailable.
 
 ## Conformance
 
-The change will be tested by twelve transactions, each transaction calling one
+The change will be tested by 18 transactions, each transaction calling one
 of the three precompiles before and after the feature activation, at top level
-and in CPI.
+with a valid signature, at top level with an valid signature and in CPI with a
+valid signature.
 
-The excpected results **before** the feature activation are:
+The expected results **before** the feature activation are:
 
-- at top level: success
-- in CPI: `CpiError::ProgramNotSupported`
+- at top level with a valid signature: success
+- at top level with an invalid signature: `PrecompileError::InvalidSignature`
+- in CPI with a valid signature: `CpiError::ProgramNotSupported`
 
-The excpected results **after** the feature activation are:
+The expected results **after** the feature activation are:
 
-- at top level: `TransactionError::InvalidProgramForExecution`
-- in CPI: `InstructionError::UnsupportedProgramId`
+- at top level with a valid signature:
+`TransactionError::InvalidProgramForExecution`
+- at top level with an invalid signature:
+`InstructionError::UnsupportedProgramId`
+- in CPI with a valid signature: `InstructionError::UnsupportedProgramId`
 
 [to be filled in before merging]

--- a/proposals/0568-deprecate-precompiles.md
+++ b/proposals/0568-deprecate-precompiles.md
@@ -19,6 +19,16 @@ Remove support for the secp256k1, secp256r1 and ed25519 precompiles.
 Precompiles are rigid, require special handling in validator implementations
 and their cross instruction referencing (in ed25519) is hacky.
 
+## Dependencies
+
+This proposal depends on the following proposals:
+
+- **[SIMD-0565]: Secp256r1 curve syscalls**
+
+    To provide an efficient alternative to the secp256r1 precompile.
+
+[SIMD-0565]: https://github.com/solana-foundation/solana-improvement-documents/pull/565
+
 ## New Terminology
 
 None.
@@ -35,6 +45,9 @@ With the activation of the feature gate their accounts must be deleted.
 
 After the activation of the feature gate:
 
+- Fee calculation must ignore them, thus not charge `lamports_per_signature`
+for them.
+- The cost tracker and other cost estimation heuristics should ignore them.
 - Every transaction invoking them with top-level instructions must
 throw `TransactionError::InvalidProgramForExecution` during transaction
 loading time.
@@ -71,6 +84,21 @@ level.
 44% of ed25519 invocations access sibling top-level instruction data. Meaning
 these would not be possible to fill in with an exact replacement right now
 (see [alternatives considered](#migrating-them-to-core-programs-on-chain)).
+
+With the cleanup, after the feature gate is activated on MNB, precompiles
+should also be removed from:
+
+- test validator genesis
+  - the program accounts of the precompiles
+- ledger tool:
+  - `fix_testnet_ed25519_precompile_account`
+- solana-sdk:
+  - `SanitizedMessage`
+  - `SVMStaticMessage`
+  - `TransactionSignatureDetails`
+  - `solana_sdk_ids`
+  - `PrecompileError`
+- tests, mockups, examples, documentation
 
 ## Security Considerations
 

--- a/proposals/0568-deprecate-precompiles.md
+++ b/proposals/0568-deprecate-precompiles.md
@@ -48,12 +48,8 @@ After the activation of the feature gate:
 - Fee calculation must ignore them, thus not charge `lamports_per_signature`
 for them.
 - The cost tracker and other cost estimation heuristics should ignore them.
-- Every transaction invoking them with top-level instructions must
-throw `TransactionError::InvalidProgramForExecution` during transaction
-loading time.
-- Every instruction invoking them with in CPI must
-throw `InstructionError::UnsupportedProgramId` instead of
-`CpiError::ProgramNotSupported` as they currently do.
+- The callee CPI restrictions for precompiles which throw
+`CpiError::ProgramNotSupported` must be removed.
 
 ### Validator Components Affected
 
@@ -114,7 +110,18 @@ Breaking change: All precompiles will become unavailable.
 
 ## Conformance
 
-The change will be tested by three transactions, each transaction calling one
-of the three precompiles before and after the feature activation.
+The change will be tested by twelve transactions, each transaction calling one
+of the three precompiles before and after the feature activation, at top level
+and in CPI.
+
+The excpected results **before** the feature activation are:
+
+- at top level: success
+- in CPI: `CpiError::ProgramNotSupported`
+
+The excpected results **after** the feature activation are:
+
+- at top level: `TransactionError::InvalidProgramForExecution`
+- in CPI: `InstructionError::UnsupportedProgramId`
 
 [to be filled in before merging]

--- a/proposals/0568-deprecate-precompiles.md
+++ b/proposals/0568-deprecate-precompiles.md
@@ -1,0 +1,109 @@
+---
+simd: '0568'
+title: Deprecate Precompiles
+authors:
+  - Alexander Meißner (Anza)
+category: Standard
+type: Core
+status: Review
+created: 2026-06-17
+feature: [to be filled in before merging]
+---
+
+## Summary
+
+Remove support for the secp256k1, secp256r1 and ed25519 precompiles.
+
+## Motivation
+
+Precompiles are rigid, require special handling in validator implementations
+and their cross instruction referencing (in ed25519) is hacky.
+
+In a discussion on Discord [^1] consensus was reached to proceed with option
+4 "Drop protocol-owned verifiers entirely and let normal programs handle this".
+
+[^1]: https://discord.com/channels/428295358100013066/1164657208613683280/1516459607726358672
+
+## New Terminology
+
+None.
+
+## Detailed Design
+
+After the activation of the feature gate every instruction attempting to invoke
+any of the following programs must fail with
+`InstructionError::UnsupportedProgramId`:
+
+- secp256k1: `KeccakSecp256k11111111111111111111111111111`
+- secp256r1: `Secp256r1SigVerify1111111111111111111111111`
+- ed25519: `Ed25519SigVerify111111111111111111111111111`
+
+As a consequence the check in CPI which prevents precompiles from being called
+and throws `CpiError::ProgramNotSupported` becomes pointless and must be
+skipped as well.
+
+### Edge Cases
+
+The three program accounts will continue to exist and be owned by the native
+loader (`NativeLoader1111111111111111111111111111111`) thus they will continue
+to count as programs during transaction loading and only be filtered out during
+instruction execution.
+
+### Validator Components Affected
+
+These changes are limited to the program runtime component
+(Transaction Execution).
+
+## Alternatives Considered
+
+### Migrating them to core programs on-chain
+
+The ed25519 one requires top-level instruction introspection, which is not
+available to programs on-chain out of the box right now. Thus it would require
+either breaking changes to the precompile or adding features to the SVM:
+
+- Require users to pas in all bytes to verify in the precompile instruction,
+forbidding cross referencing other instructions.
+- Require users to pass in the instructions sysvar account.
+- Add an instructions sysvar syscall, or some other mechanism to access it.
+
+### Where to place the check
+
+The check could also be placed at transaction loading time and throw
+`TransactionError::InvalidProgramForExecution` when any top-level instruction
+for a precompile is detected. This however would still leave the CPI callee
+special case relevant.
+
+## Impact
+
+The community will have to develop their own on-chain replacements.
+However, this is also an opportunity as solutions using crypto syscalls can be
+cheaper compared to the lamports charged for signature verification at the
+transaction level.
+
+According to Sam Kim about 44% of ed25519 invocations access sibling top-level
+instruction data. Meaning these would not be possible to fill in with an
+exact replacement right now
+(see [alternatives considered](#migrating-them-to-core-programs-on-chain)).
+
+## Security Considerations
+
+Implementation-specific guidance will be required for transaction builder
+clients and dApp devs who develop the on-chain replacements. Preferably we
+should provide canonical replacements, which is different from a core program
+as these replacements would life under different addresses and have different
+interfaces.
+
+On the validator implementation side this change is a pure removal of features
+and should thus not have any security pitfalls.
+
+## Backwards Compatibility
+
+Breaking change: All precompiles will become unavailable.
+
+## Conformance
+
+The change will be tested by three transactions, each transaction calling one
+of the three precompiles before and after the feature activation.
+
+[to be filled in before merging]

--- a/proposals/0568-deprecate-precompiles.md
+++ b/proposals/0568-deprecate-precompiles.md
@@ -19,35 +19,28 @@ Remove support for the secp256k1, secp256r1 and ed25519 precompiles.
 Precompiles are rigid, require special handling in validator implementations
 and their cross instruction referencing (in ed25519) is hacky.
 
-In a discussion on Discord [^1] consensus was reached to proceed with option
-4 "Drop protocol-owned verifiers entirely and let normal programs handle this".
-
-[^1]: https://discord.com/channels/428295358100013066/1164657208613683280/1516459607726358672
-
 ## New Terminology
 
 None.
 
 ## Detailed Design
 
-After the activation of the feature gate every instruction attempting to invoke
-any of the following programs must fail with
-`InstructionError::UnsupportedProgramId`:
+The addresses of the precompiles are:
 
 - secp256k1: `KeccakSecp256k11111111111111111111111111111`
 - secp256r1: `Secp256r1SigVerify1111111111111111111111111`
 - ed25519: `Ed25519SigVerify111111111111111111111111111`
 
-As a consequence the check in CPI which prevents precompiles from being called
-and throws `CpiError::ProgramNotSupported` becomes pointless and must be
-skipped as well.
+With the activation of the feature gate their accounts must be deleted.
 
-### Edge Cases
+After the activation of the feature gate:
 
-The three program accounts will continue to exist and be owned by the native
-loader (`NativeLoader1111111111111111111111111111111`) thus they will continue
-to count as programs during transaction loading and only be filtered out during
-instruction execution.
+- Every transaction invoking them with top-level instructions must
+throw `TransactionError::InvalidProgramForExecution` during transaction
+loading time.
+- Every instruction invoking them with in CPI must
+throw `InstructionError::UnsupportedProgramId` instead of
+`CpiError::ProgramNotSupported` as they currently do.
 
 ### Validator Components Affected
 
@@ -59,40 +52,30 @@ These changes are limited to the program runtime component
 ### Migrating them to core programs on-chain
 
 The ed25519 one requires top-level instruction introspection, which is not
-available to programs on-chain out of the box right now. Thus it would require
-either breaking changes to the precompile or adding features to the SVM:
+available to programs on-chain without the Instructions sysvar. Thus it would
+require either breaking changes to the precompile or adding features to the
+SVM:
 
-- Require users to pas in all bytes to verify in the precompile instruction,
+- Require users to pass in all bytes to verify in the precompile instruction,
 forbidding cross referencing other instructions.
 - Require users to pass in the instructions sysvar account.
 - Add an instructions sysvar syscall, or some other mechanism to access it.
 
-### Where to place the check
-
-The check could also be placed at transaction loading time and throw
-`TransactionError::InvalidProgramForExecution` when any top-level instruction
-for a precompile is detected. This however would still leave the CPI callee
-special case relevant.
-
 ## Impact
 
-The community will have to develop their own on-chain replacements.
-However, this is also an opportunity as solutions using crypto syscalls can be
-cheaper compared to the lamports charged for signature verification at the
-transaction level.
+The community will have to develop their own on-chain replacements. However,
+this is also an opportunity as solutions using crypto syscalls can be cheaper
+compared to the lamports charged for signature verification at the transaction
+level.
 
-According to Sam Kim about 44% of ed25519 invocations access sibling top-level
-instruction data. Meaning these would not be possible to fill in with an
-exact replacement right now
+44% of ed25519 invocations access sibling top-level instruction data. Meaning
+these would not be possible to fill in with an exact replacement right now
 (see [alternatives considered](#migrating-them-to-core-programs-on-chain)).
 
 ## Security Considerations
 
 Implementation-specific guidance will be required for transaction builder
-clients and dApp devs who develop the on-chain replacements. Preferably we
-should provide canonical replacements, which is different from a core program
-as these replacements would life under different addresses and have different
-interfaces.
+clients and dApp devs who develop the on-chain replacements.
 
 On the validator implementation side this change is a pure removal of features
 and should thus not have any security pitfalls.


### PR DESCRIPTION
In a discussion on Discord [^1] consensus was reached to proceed with option
4 "Drop protocol-owned verifiers entirely and let normal programs handle this".

[^1]: https://discord.com/channels/428295358100013066/1164657208613683280/1516459607726358672