### PR TITLE
Correct bank hash components in SIMD-0298

### DIFF
--- a/proposals/0298-bank-hash-in-block-footer.md
+++ b/proposals/0298-bank-hash-in-block-footer.md
@@ -109,7 +109,7 @@ complete execution state and is calculated from several components:
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 | last_blockhash             (32 bytes) |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-| accounts_lt_hash_checksum  (32 bytes) |
+| accounts_lt_hash         (2048 bytes) |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 
 ```
@@ -119,8 +119,8 @@ complete execution state and is calculated from several components:
 - `parent_bank_hash` - Hash of the parent bank's state (32 bytes)
 - `signature_count` - Total number of signatures processed in the bank (64 bits)
 - `last_blockhash` - The blockhash used for transaction processing (32 bytes)
-- `accounts_lt_hash_checksum` - Checksum of the accounts ledger tree (32 bytes)
-- `accounts` - Detailed account state information (variable size)
+- `accounts_lt_hash` - The accounts lattice hash, hashed in full as its
+  1024-element `u16` array (2048 bytes)
 
 **Optional Component:**
 


### PR DESCRIPTION
Two factual corrections to the "Bank Hash Structure" section. Checked against agave `3eeb5658f18ff59c04949110f56ff1c30b21e9a1`.

`Bank::hash_internal_state` (`runtime/src/bank.rs:5392-5407`):

```rust
let mut hash = hashv(&[
    self.parent_hash.as_ref(),
    &self.signature_count().to_le_bytes(),
    self.last_blockhash().as_ref(),
]);

let accounts_lt_hash_checksum = {
    let accounts_lt_hash = &*self.accounts_lt_hash.lock().unwrap();
    let lt_hash_bytes = bytemuck::must_cast_slice(&accounts_lt_hash.0.0);
    hash = hashv(&[hash.as_ref(), lt_hash_bytes]);
    accounts_lt_hash.0.checksum()
};
```

**1. It is the full lattice hash, not the checksum.** `accounts_lt_hash.0.0` is `[u16; LtHash::NUM_ELEMENTS]` with `NUM_ELEMENTS = 1024` (`lattice-hash/src/lt_hash.rs:12-15`), so `must_cast_slice` yields 2048 bytes and the entire array is hashed in. `checksum()` is evaluated as the value of that block and used for logging and metrics — it is not an input to the bank hash. The document currently lists `accounts_lt_hash_checksum (32 bytes)` in both the diagram and the component list.

**2. There is no `accounts` component.** The bullet `accounts - Detailed account state information (variable size)` corresponds to nothing in the computation; account state enters the bank hash only through the lattice hash. Removed.

The **Optional Component** note on hard fork data is correct as written (`runtime/src/bank.rs:5409-5418`) and is left unchanged.

The diagram keeps its original 41-column width, so the only change there is the one field line.